### PR TITLE
Update PSGSuite2.psd1

### DIFF
--- a/PSGSuite2/PSGSuite2.psd1
+++ b/PSGSuite2/PSGSuite2.psd1
@@ -54,7 +54,7 @@ In order to use this module, you''ll need to have the following:
 '
 
 # Minimum version of the Windows PowerShell engine required by this module
-PowerShellVersion = '3.0'
+PowerShellVersion = '5.1'
 
 # Compatible PowerShell editions
 CompatiblePSEditions = 'Desktop','Core'


### PR DESCRIPTION
5.1 is the minimum version of PowerShell due to the key of CompatiblePSEditions in PSGSuite2.psd1