### PR TITLE
Group settings not updating the "whoCanJoin" property.

### DIFF
--- a/Public/Update-GSGroupSettings.ps1
+++ b/Public/Update-GSGroupSettings.ps1
@@ -139,7 +139,7 @@ $header = @{
 $body = @{}
 if ($Name){$body.Add("name",$Name)}
 if ($Description){$body.Add("description",$Description)}
-if ($WhoCanJoin){$body.Add("WhoCanJoin",$WhoCanJoin)}
+if ($WhoCanJoin){$body.Add("whoCanJoin",$WhoCanJoin)}
 if ($WhoCanViewMembership){$body.Add("whoCanViewMembership",$WhoCanViewMembership)}
 if ($WhoCanViewGroup){$body.Add("whoCanViewGroup",$WhoCanViewGroup)}
 if ($WhoCanInvite){$body.Add("whoCanInvite",$WhoCanInvite)}


### PR DESCRIPTION
Confirmed with Google that the reason this does not update this property is due to the capital "W" in the request. I have tested and confirmed this to be the case.