### PR TITLE
!build fixes for #39

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 <!-- TOC -->
 
 - [Changelog](#changelog)
+  - [2.5.2](#252)
+  - [2.5.1](#251)
   - [2.5.0](#250)
   - [2.4.0](#240)
   - [2.3.0](#230)
@@ -24,6 +26,10 @@
       - [Functions Aliased](#functions-aliased)
 
 <!-- /TOC -->
+
+## 2.5.2
+
+* Fixed: `Update-GSUser -CustomSchemas @{schema = @{field = "value"}}` resulting in null array (Resolve [Issue #39](https://github.com/scrthq/PSGSuite/issues/39))
 
 ## 2.5.1
 

--- a/PSGSuite/PSGSuite.psd1
+++ b/PSGSuite/PSGSuite.psd1
@@ -12,7 +12,7 @@
     RootModule            = 'PSGSuite.psm1'
 
     # Version number of this module.
-    ModuleVersion         = '2.5.1'
+    ModuleVersion         = '2.5.2'
 
     # ID used to uniquely identify this module
     GUID                  = '9d751152-e83e-40bb-a6db-4c329092aaec'

--- a/PSGSuite/Public/Users/Update-GSUser.ps1
+++ b/PSGSuite/Public/Users/Update-GSUser.ps1
@@ -197,7 +197,7 @@ function Update-GSUser {
                         $schemaDict = New-Object 'System.Collections.Generic.Dictionary`2[[System.String],[System.Collections.Generic.IDictionary`2[[System.String],[System.Object]]]]'
                         foreach ($schemaName in $CustomSchemas.Keys) {
                             $fieldDict = New-Object 'System.Collections.Generic.Dictionary`2[[System.String],[System.Object]]'
-                            $schemaFields = $CustomSchema[$schemaName]
+                            $schemaFields = $CustomSchemas[$schemaName]
                             $schemaFields.Keys | ForEach-Object {
                                 $fieldDict.Add($_,$schemaFields[$_])
                             }

--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ Update-GSSheetValue               Export-GSSheet
 
 ### Most recent changes
 
+#### 2.5.2
+
+* Fixed: `Update-GSUser -CustomSchemas @{schema = @{field = "value"}}` resulting in null array (Resolve [Issue #39](https://github.com/scrthq/PSGSuite/issues/39))
+
 #### 2.5.1
 
 * Fixed: `Add-GSGmailDelegate` and `Remove-GSGmailDelegate` returning 400 Bad Request responses (Resolve [Issue #35](https://github.com/scrthq/PSGSuite/issues/35))


### PR DESCRIPTION
## 2.5.2
 
* Fixed: `Update-GSUser -CustomSchemas @{schema = @{field = "value"}}` resulting in null array (Resolve [Issue #39](https://github.com/scrthq/PSGSuite/issues/39))