### PR TITLE
!build v2.5.3 - multi domain support for #32 and perf increase for #38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- TOC -->
 
 - [Changelog](#changelog)
+  - [2.5.3](#253)
   - [2.5.2](#252)
   - [2.5.1](#251)
   - [2.5.0](#250)
@@ -26,6 +27,12 @@
       - [Functions Aliased](#functions-aliased)
 
 <!-- /TOC -->
+
+## 2.5.3
+
+* Fixed/Added: Specific domain support for listing users with `Get-GSUser -Filter $filter -Domain domain2.com` to allow customers with multiple domains to only list users for a specific domain instead of just the entire customer or domain saved in the config. (Resolve [Issue #32](https://github.com/scrthq/PSGSuite/issues/32))
+* Added: Better verbose output in when listing users
+* Fixed: Performance increase in `Get-GSDriveFileList` but returning DriveFile objects as it iterates through each page instead of storing in an array and returning the array at the end (Resolve [Issue #38](https://github.com/scrthq/PSGSuite/issues/38))
 
 ## 2.5.2
 

--- a/PSGSuite/PSGSuite.psd1
+++ b/PSGSuite/PSGSuite.psd1
@@ -12,7 +12,7 @@
     RootModule            = 'PSGSuite.psm1'
 
     # Version number of this module.
-    ModuleVersion         = '2.5.2'
+    ModuleVersion         = '2.5.3'
 
     # ID used to uniquely identify this module
     GUID                  = '9d751152-e83e-40bb-a6db-4c329092aaec'

--- a/PSGSuite/Private/ListPrivate/Get-GSUserListPrivate.ps1
+++ b/PSGSuite/Private/ListPrivate/Get-GSUserListPrivate.ps1
@@ -7,6 +7,9 @@ function Get-GSUserListPrivate {
         [String[]]
         $Filter = "*",
         [parameter(Mandatory = $false)]
+        [String]
+        $Domain,
+        [parameter(Mandatory = $false)]
         [Alias("OrgUnitPath")]
         [String]
         $SearchBase,
@@ -53,7 +56,11 @@ function Get-GSUserListPrivate {
         try {
             $request = $service.Users.List()
             $request.Projection = $Projection
-            if ($Script:PSGSuite.Preference) {
+            if ($PSBoundParameters.Keys -contains 'Domain') {
+                $verbScope = "domain '$($PSBoundParameters['Domain'])'"
+                $request.Domain = $PSBoundParameters['Domain']
+            }
+            elseif ($Script:PSGSuite.Preference) {
                 switch ($Script:PSGSuite.Preference) {
                     Domain {
                         $verbScope = "domain '$($Script:PSGSuite.Domain)'"
@@ -109,6 +116,9 @@ function Get-GSUserListPrivate {
             }
             until (!$result.NextPageToken)
             if ($SearchScope -ne "Subtree") {
+                if (!$SearchBase) {
+                    $SearchBase = "/"
+                }
                 $response = switch ($SearchScope) {
                     Base {
                         $response | Where-Object {$_.OrgUnitPath -eq $SearchBase}

--- a/PSGSuite/Public/Drive/Get-GSDriveFileList.ps1
+++ b/PSGSuite/Public/Drive/Get-GSDriveFileList.ps1
@@ -138,11 +138,10 @@ function Get-GSDriveFileList {
             else {
                 Write-Verbose "Getting all Drive Files for user '$User'"
             }
-            $response = @()
             [int]$i = 1
             do {
                 $result = $request.Execute()
-                $response += $result.Files | Select-Object @{N = 'User';E = {$User}},*
+                $result.Files | Select-Object @{N = 'User';E = {$User}},*
                 if ($result.NextPageToken) {
                     $request.PageToken = $result.NextPageToken
                 }
@@ -151,7 +150,6 @@ function Get-GSDriveFileList {
                 [int]$i = $i + $result.Files.Count
             }
             until (!$result.NextPageToken)
-            $response
         }
         catch {
             if ($ErrorActionPreference -eq 'Stop') {

--- a/PSGSuite/Public/Users/Get-GSUser.ps1
+++ b/PSGSuite/Public/Users/Get-GSUser.ps1
@@ -17,12 +17,15 @@ function Get-GSUser {
     For more information on constructing user queries, see: https://developers.google.com/admin-sdk/directory/v1/guides/search-users
 
     PowerShell filter syntax here is supported as "best effort". Please use Google's filter operators and syntax to ensure best results
+
+    .PARAMETER Domain
+    The specific domain you would like to list users for. Useful for customers with multiple domains.
     
     .PARAMETER SearchBase
     The organizational unit path that you would like to list users from
     
     .PARAMETER SearchScope
-    The depth at which to return the list of Users
+    The depth at which to return the list of users
 
     Available values are:
     * "Base": only return the users specified in the SearchBase
@@ -103,6 +106,9 @@ function Get-GSUser {
         [Alias("Query")]
         [String[]]
         $Filter,
+        [parameter(Mandatory = $false,ParameterSetName = "List")]
+        [String]
+        $Domain,
         [parameter(Mandatory = $false,ParameterSetName = "List")]
         [Alias("OrgUnitPath")]
         [String]

--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ Update-GSSheetValue               Export-GSSheet
 
 ### Most recent changes
 
+#### 2.5.3
+
+* Fixed/Added: Specific domain support for listing users with `Get-GSUser -Filter $filter -Domain domain2.com` to allow customers with multiple domains to only list users for a specific domain instead of just the entire customer or domain saved in the config. (Resolve [Issue #32](https://github.com/scrthq/PSGSuite/issues/32))
+* Added: Better verbose output in when listing users
+* Fixed: Performance increase in `Get-GSDriveFileList` but returning DriveFile objects as it iterates through each page instead of storing in an array and returning the array at the end (Resolve [Issue #38](https://github.com/scrthq/PSGSuite/issues/38))
+
 #### 2.5.2
 
 * Fixed: `Update-GSUser -CustomSchemas @{schema = @{field = "value"}}` resulting in null array (Resolve [Issue #39](https://github.com/scrthq/PSGSuite/issues/39))


### PR DESCRIPTION
## 2.5.3

* Fixed/Added: Specific domain support for listing users with `Get-GSUser -Filter $filter -Domain domain2.com` to allow customers with multiple domains to only list users for a specific domain instead of just the entire customer or domain saved in the config. (Resolve [Issue #32](https://github.com/scrthq/PSGSuite/issues/32))
* Added: Better verbose output in when listing users
* Fixed: Performance increase in `Get-GSDriveFileList` but returning DriveFile objects as it iterates through each page instead of storing in an array and returning the array at the end (Resolve [Issue #38](https://github.com/scrthq/PSGSuite/issues/38))