### PR TITLE
pushing fixes for issue #59

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- TOC -->
 
 - [Changelog](#changelog)
+    - [2.7.1](#271)
     - [2.7.0](#270)
     - [2.6.3](#263)
     - [2.6.2](#262)
@@ -33,6 +34,10 @@
             - [Functions Aliased](#functions-aliased)
 
 <!-- /TOC -->
+
+## 2.7.1
+
+* Fixed: `Update-GSCalendarEvent` had default values set for LocalStartDateTime and LocalEndDateTime parameters, causing those to always update the event unexpectedly if a start and/or end datetime was not passed when running the command ([Issue #59](https://github.com/scrthq/PSGSuite/issues/59))
 
 ## 2.7.0
 

--- a/PSGSuite/PSGSuite.psd1
+++ b/PSGSuite/PSGSuite.psd1
@@ -12,7 +12,7 @@
     RootModule            = 'PSGSuite.psm1'
 
     # Version number of this module.
-    ModuleVersion         = '2.7.0'
+    ModuleVersion         = '2.7.1'
 
     # ID used to uniquely identify this module
     GUID                  = '9d751152-e83e-40bb-a6db-4c329092aaec'

--- a/PSGSuite/Public/Calendar/Update-GSCalendarEvent.ps1
+++ b/PSGSuite/Public/Calendar/Update-GSCalendarEvent.ps1
@@ -101,10 +101,10 @@ function Update-GSCalendarEvent {
         $EventColor,
         [parameter(Mandatory = $false)]
         [DateTime]
-        $LocalStartDateTime = (Get-Date),
+        $LocalStartDateTime,
         [parameter(Mandatory = $false)]
         [DateTime]
-        $LocalEndDateTime = (Get-Date).AddMinutes(30),
+        $LocalEndDateTime,
         [parameter(Mandatory = $false)]
         [String]
         $StartDate,
@@ -180,7 +180,7 @@ function Update-GSCalendarEvent {
                             Date = (Get-Date $StartDate -Format "yyyy-MM-dd")
                         }
                     }
-                    else {
+                    elseif ($LocalStartDateTime) {
                         New-Object 'Google.Apis.Calendar.v3.Data.EventDateTime' -Property @{
                             DateTime = $LocalStartDateTime
                         }
@@ -195,7 +195,7 @@ function Update-GSCalendarEvent {
                             Date = (Get-Date $EndDate -Format "yyyy-MM-dd")
                         }
                     }
-                    else {
+                    elseif ($LocalEndDateTime) {
                         New-Object 'Google.Apis.Calendar.v3.Data.EventDateTime' -Property @{
                             DateTime = $LocalEndDateTime
                         }

--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ Update-GSSheetValue               Export-GSSheet
 
 ### Most recent changes
 
+#### 2.7.1
+
+* Fixed: `Update-GSCalendarEvent` had default values set for LocalStartDateTime and LocalEndDateTime parameters, causing those to always update the event unexpectedly if a start and/or end datetime was not passed when running the command ([Issue #59](https://github.com/scrthq/PSGSuite/issues/59))
+
 #### 2.7.0
 
 * Added: `Get-GSCalendarACL` and `New-GSCalendarACL` for pulling/adding calendar ACL's.


### PR DESCRIPTION

#### 2.7.1

* Fixed: `Update-GSCalendarEvent` had default values set for LocalStartDateTime and LocalEndDateTime parameters, causing those to always update the event unexpectedly if a start and/or end datetime was not passed when running the command ([Issue #59](https://github.com/scrthq/PSGSuite/issues/59))
