### PR TITLE
Feature/admin mgmt issue54

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- TOC -->
 
 - [Changelog](#changelog)
+  - [2.9.0](#290)
   - [2.8.1](#281)
   - [2.8.0](#280)
   - [2.7.2](#272)
@@ -37,6 +38,12 @@
       - [Functions Aliased](#functions-aliased)
 
 <!-- /TOC -->
+
+## 2.9.0
+
+* Updated: Added `IsAdmin` switch parameter to `Update-GSUser`, allowing set or revoke SuperAdmin privileges for a user ([Issue #54](https://github.com/scrthq/PSGSuite/issues/54))
+* Added: `Get-GSAdminRole`, `New-GSAdminRole`, `Remove-GSAdminRole`& `Update-GSAdminRole` to manage Admin Roles in G Suite ([Issue #54](https://github.com/scrthq/PSGSuite/issues/54))
+* Added: `Get-GSAdminRoleAssignment`, `New-GSAdminRoleAssignment` & `Remove-GSAdminRoleAssignment` to manage Admin Role Assignments in G Suite ([Issue #54](https://github.com/scrthq/PSGSuite/issues/54))
 
 ## 2.8.1
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,10 +4,13 @@
 
 - [Contributing to PSGSuite](#contributing-to-psgsuite)
     - [Git and Pull requests](#git-and-pull-requests)
-    - [Getting Started](#getting-started)
+    - [Overview](#overview)
         - [Step by Step](#step-by-step)
-        - [Style Guidelines](#style-guidelines)
+        - [Contributing Guidelines](#contributing-guidelines)
+        - [Updating the Wiki](#updating-the-wiki)
+    - [Getting Started](#getting-started)
         - [Enabling Debug Mode](#enabling-debug-mode)
+        - [Google .NET SDK Documentation](#google-net-sdk-documentation)
     - [Keeping in Touch](#keeping-in-touch)
 
 <!-- /TOC -->
@@ -19,7 +22,7 @@ Thank you for your interest in helping PSGSuite grow! Below you'll find some gui
 * Contributions are submitted, reviewed, and accepted using Github pull requests. [Read this article](https://help.github.com/articles/using-pull-requests) for some details. We use the _Fork and Pull_ model, as described there. More info can be found here: [Forking Projects](https://guides.github.com/activities/forking/)
 * Please make sure to leave the `Allow edits from maintainers` box checked when submitting PR's so that any edits can be made by maintainers of the repo directly to the source branch and into the same PR. More info can be found here: [Allowing changes to a pull request branch created from a fork](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/#enabling-repository-maintainer-permissions-on-existing-pull-requests)
 
-## Getting Started
+## Overview
 
 ### Step by Step
 
@@ -31,7 +34,7 @@ Here's the overall flow of making contributions:
 5. Pull request is reviewed. Any necessary edits / suggestions will be made
 6. Once changes are approved, the pull request is merged into the origin's master branch and deployed to the PowerShell Gallery once CI tests pass in AppVeyor
 
-### Style Guidelines
+### Contributing Guidelines
 
 Please follow these guidelines for any content being added:
 
@@ -44,6 +47,10 @@ Please follow these guidelines for any content being added:
     * include comment-based help (this is used to drive the Wiki updates on deployment)
     * include Write-Verbose calls to describe what the function is doing (CI tests will fail the build if any don't)
     * be placed in the correct APU/use-case folder in the Public sub-directory of the module path (if it's a new API/use-case, create the new folder as well)
+    * use `SupportsShouldProcess` if...
+        * the function's verb is `Remove` or `Set`. 
+        * it can be included on `Update` functions as well, if felt that the actions executed by the function should be guarded
+        * `Get` functions should **never** need `SupportsShouldProcess`
 * **Every Pull Request must...**
     > These can be added in during the pull request review process, but are nice to have if possible
     * have the module version bumped appropriately in the manifest (Major for any large updates, Minor for any new functionality, Patch for any hotfixes)
@@ -52,6 +59,13 @@ Please follow these guidelines for any content being added:
     * have an entry in the ReadMe's `Most recent changes` section describing what was added, updated and/or fixed with this version number
         * *Please follow the same format already present*
         * *This can be copied over from the Changelog entry*
+
+### Updating the Wiki
+
+* Wiki updates are scripted during deployment builds, so there is no need to manually update the Wiki. 
+* Any new or updated comment-based help content will be transformed to Markdown using `platyPS` and pushed to the Wiki repo when deployment conditions are met.
+
+## Getting Started
 
 ### Enabling Debug Mode
 
@@ -82,6 +96,22 @@ $request = $service.Users.List()
 # Execute the request to return the results
 $request.Execute()
 ```
+
+### Google .NET SDK Documentation
+
+PSGSuite uses Google's .NET SDK's for 99% of its functions. The easiest way to pull up the documentation for the function you are writing is by doing the following (*using the Admin Directory API as an example*):
+
+1. Find Google's API information for the function you're writing
+    * Usually the first result when searching for specific API's in Google:
+        * Search: `google admin directory api`
+        * Result: [G Suite Admin SDK Directory API](https://developers.google.com/admin-sdk/directory/)
+2. Open the **Guides** tab
+3. Click the **.NET** section under the `Quickstarts` header in the side menu
+4. Scroll to the bottom of the page and click the link for the **.NET reference documentation** under the **Further reading** header. For the Admin Directory API, it's: [Directory API .NET reference documentation](https://developers.google.com/resources/api-libraries/documentation/admin/directory_v1/csharp/latest/)
+5. Click the **Classes** dropdown on the top-left of the page, then click **Class List**
+6. Find the resource class you are looking for. Resource classes all end in `Resource`, i.e. `UsersResource` or `OrgunitResource`.
+7. Find the request method specific to your function. Request methods all end in `Request`, i.e. `ListRequest` or `InsertRequest`.
+
 
 ## Keeping in Touch
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@
     - [Getting Started](#getting-started)
         - [Enabling Debug Mode](#enabling-debug-mode)
         - [Google .NET SDK Documentation](#google-net-sdk-documentation)
+            - [.NET/API Documentation Links](#netapi-documentation-links)
     - [Keeping in Touch](#keeping-in-touch)
 
 <!-- /TOC -->
@@ -105,6 +106,7 @@ PSGSuite uses Google's .NET SDK's for 99% of its functions. The easiest way to p
     * Usually the first result when searching for specific API's in Google:
         * Search: `google admin directory api`
         * Result: [G Suite Admin SDK Directory API](https://developers.google.com/admin-sdk/directory/)
+    * **See the [Documentation Links](#netapi-documentation-links) section below for some handy links**
 2. Open the **Guides** tab
 3. Click the **.NET** section under the `Quickstarts` header in the side menu
 4. Scroll to the bottom of the page and click the link for the **.NET reference documentation** under the **Further reading** header. For the Admin Directory API, it's: [Directory API .NET reference documentation](https://developers.google.com/resources/api-libraries/documentation/admin/directory_v1/csharp/latest/)
@@ -112,6 +114,25 @@ PSGSuite uses Google's .NET SDK's for 99% of its functions. The easiest way to p
 6. Find the resource class you are looking for. Resource classes all end in `Resource`, i.e. `UsersResource` or `OrgunitResource`.
 7. Find the request method specific to your function. Request methods all end in `Request`, i.e. `ListRequest` or `InsertRequest`.
 
+#### .NET/API Documentation Links
+
+Here are some links to the most commonly used SDK's and API's in PSGSuite:
+
+* **Admin SDK: Directory API**
+    * [.NET SDK Documentation](https://developers.google.com/resources/api-libraries/documentation/admin/directory_v1/csharp/latest/index.html)
+    * [API Documentation](https://developers.google.com/admin-sdk/directory/v1/reference/)
+* **Drive SDK**
+    * [.NET SDK Documentation](https://developers.google.com/resources/api-libraries/documentation/drive/v3/csharp/latest/)
+    * [API Documentation](https://developers.google.com/drive/api/v3/reference/)
+* **Sheets API**
+    * [.NET SDK Documentation](https://developers.google.com/resources/api-libraries/documentation/sheets/v4/csharp/latest/)
+    * [API Documentation](https://developers.google.com/sheets/api/reference/rest/)
+* **Gmail API**
+    * [.NET SDK Documentation](https://developers.google.com/resources/api-libraries/documentation/gmail/v1/csharp/latest/)
+    * [API Documentation](https://developers.google.com/gmail/api/v1/reference/)
+* **Calendar API**
+    * [.NET SDK Documentation](https://developers.google.com/resources/api-libraries/documentation/calendar/v3/csharp/latest/)
+    * [API Documentation](https://developers.google.com/calendar/v3/reference/)
 
 ## Keeping in Touch
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,88 @@
+# Contributing to PSGSuite
+
+<!-- TOC -->
+
+- [Contributing to PSGSuite](#contributing-to-psgsuite)
+    - [Git and Pull requests](#git-and-pull-requests)
+    - [Getting Started](#getting-started)
+        - [Step by Step](#step-by-step)
+        - [Style Guidelines](#style-guidelines)
+        - [Enabling Debug Mode](#enabling-debug-mode)
+    - [Keeping in Touch](#keeping-in-touch)
+
+<!-- /TOC -->
+
+Thank you for your interest in helping PSGSuite grow! Below you'll find some guidelines around developing additional features and squashing bugs, including some how-to's to get started quick, general style guidelines, etc.
+
+## Git and Pull requests
+
+* Contributions are submitted, reviewed, and accepted using Github pull requests. [Read this article](https://help.github.com/articles/using-pull-requests) for some details. We use the _Fork and Pull_ model, as described there. More info can be found here: [Forking Projects](https://guides.github.com/activities/forking/)
+* Please make sure to leave the `Allow edits from maintainers` box checked when submitting PR's so that any edits can be made by maintainers of the repo directly to the source branch and into the same PR. More info can be found here: [Allowing changes to a pull request branch created from a fork](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/#enabling-repository-maintainer-permissions-on-existing-pull-requests)
+
+## Getting Started
+
+### Step by Step
+
+Here's the overall flow of making contributions:  
+1. Fork the repo
+2. Make your edits / additions on your fork
+3. Push your changes back to your fork on GitHub
+4. Submit a pull request
+5. Pull request is reviewed. Any necessary edits / suggestions will be made
+6. Once changes are approved, the pull request is merged into the origin's master branch and deployed to the PowerShell Gallery once CI tests pass in AppVeyor
+
+### Style Guidelines
+
+Please follow these guidelines for any content being added:
+
+* **ALL functions must...**
+    * work in the supported PowerShell versions by this module
+    * work in any OS;
+        * any code that includes paths must build the path using OS-agnostic methods, i.e. by using `Resolve-Path`, `Join-Path` and `Split-Path`
+        * paths also need to use correct casing, as some OS's are case-sensitive in terms of paths
+* **Public functions must...** 
+    * include comment-based help (this is used to drive the Wiki updates on deployment)
+    * include Write-Verbose calls to describe what the function is doing (CI tests will fail the build if any don't)
+    * be placed in the correct APU/use-case folder in the Public sub-directory of the module path (if it's a new API/use-case, create the new folder as well)
+* **Every Pull Request must...**
+    > These can be added in during the pull request review process, but are nice to have if possible
+    * have the module version bumped appropriately in the manifest (Major for any large updates, Minor for any new functionality, Patch for any hotfixes)
+    * have an entry in the Changelog describing what was added, updated and/or fixed with this version number
+        * *Please follow the same format already present*
+    * have an entry in the ReadMe's `Most recent changes` section describing what was added, updated and/or fixed with this version number
+        * *Please follow the same format already present*
+        * *This can be copied over from the Changelog entry*
+
+### Enabling Debug Mode
+
+To enable debug mode and export the `New-GoogleService` function with the module, you can run the `Debub Mode.ps1` script in the `tools` folder in the root of the repo or the following lines of code from the root of the repo in PowerShell:
+
+```powershell
+$env:EnablePSGSuiteDebug = $true
+Import-Module (Join-Path (Join-Path "." "PSGSuite") "PSGSuite.psd1") -Force
+```
+
+Debug mode is useful as it gives you access to the `New-GoogleService` function. This is normally a private function that is used by most other functions to create `Google Service` object with which to create and execute requests with. For example:
+
+```powershell
+$serviceParams = @{
+    # This needs to be one of the scopes that the request method invoked by the function needs
+    Scope       = 'https://www.googleapis.com/auth/admin.directory.user'
+    # This is the Google SDK Service Type used by all classes/methods in that category.
+    # Most of the calls in PSGSuite use the below DirectoryService, as that houses the Google Admin SDK
+    ServiceType = 'Google.Apis.Admin.Directory.directory_v1.DirectoryService'
+}
+
+# Create the Google Service object and store that in the $service variable
+$service = New-GoogleService @serviceParams
+
+# Create the request object using the $service and store that in the $request variable
+$request = $service.Users.List()
+
+# Execute the request to return the results
+$request.Execute()
+```
+
+## Keeping in Touch
+
+For any questions, comments or concerns outside of opening an issue, please join us in the `#psgsuite` channel on the SCRT HQ Slack; Team: `scrthq.slack.com`. [Click here](https://scrthq-slack-invite.herokuapp.com/) to get an invite!

--- a/PSGSuite/PSGSuite.psd1
+++ b/PSGSuite/PSGSuite.psd1
@@ -12,7 +12,7 @@
     RootModule            = 'PSGSuite.psm1'
 
     # Version number of this module.
-    ModuleVersion         = '2.8.1'
+    ModuleVersion         = '2.9.0'
 
     # ID used to uniquely identify this module
     GUID                  = '9d751152-e83e-40bb-a6db-4c329092aaec'

--- a/PSGSuite/PSGSuite.psm1
+++ b/PSGSuite/PSGSuite.psm1
@@ -129,5 +129,11 @@ catch {
     Write-Warning "There was no config returned! Please make sure you are using the correct key or have a configuration already saved."
 }
 finally {
-    Export-ModuleMember -Function ($Public.Basename) -Alias *
+    $functionsToExport = if ($env:EnablePSGSuiteDebug) {
+        ($Public.Basename + 'New-GoogleService')
+    }
+    else {
+        $Public.Basename
+    }
+    Export-ModuleMember -Function $functionsToExport -Alias *
 }

--- a/PSGSuite/Public/RoleAssignments/Get-GSAdminRoleAssignment.ps1
+++ b/PSGSuite/Public/RoleAssignments/Get-GSAdminRoleAssignment.ps1
@@ -1,0 +1,186 @@
+function Get-GSAdminRoleAssignment {
+    <#
+    .SYNOPSIS
+    Gets a specific Admin Role Assignments or the list of Admin Role Assignments for a given role
+    
+    .DESCRIPTION
+    Gets a specific Admin Role Assignments or the list of Admin Role Assignments for a given role
+    
+    .PARAMETER RoleAssignmentId
+    The RoleAssignmentId(s) you would like to retrieve info for.
+
+    If left blank, returns the full list of Role Assignments
+    
+    .PARAMETER UserKey
+    The UserKey(s) you would like to retrieve Role Assignments for. This can be a user's email or their unique UserId
+
+    If left blank, returns the full list of Role Assignments
+    
+    .PARAMETER RoleId
+    The RoleId(s) you would like to retrieve Role Assignments for.
+
+    If left blank, returns the full list of Role Assignments
+    
+    .PARAMETER PageSize
+    Page size of the result set
+    
+    .EXAMPLE
+    Get-GSAdminRoleAssignment
+
+    Gets the list of Admin Role Assignments
+    
+    .EXAMPLE
+    Get-GSAdminRoleAssignment -RoleId 9191482342768644,9191482342768642
+
+    Gets the Admin Role Assignments matching the provided RoleIds
+    #>
+    [cmdletbinding(DefaultParameterSetName = "ListUserKey")]
+    Param
+    (
+        [parameter(Mandatory = $true,Position = 0,ParameterSetName = "Get")]
+        [String[]]
+        $RoleAssignmentId,
+        [parameter(Mandatory = $false,ParameterSetName = "ListUserKey")]
+        [string[]]
+        $UserKey,
+        [parameter(Mandatory = $false,ParameterSetName = "ListRoleId")]
+        [string[]]
+        $RoleId,
+        [parameter(Mandatory = $false,ParameterSetName = "ListUserKey")]
+        [parameter(Mandatory = $false,ParameterSetName = "ListRoleId")]
+        [ValidateRange(1,100)]
+        [Alias("MaxResults")]
+        [Int]
+        $PageSize
+    )
+    Begin {
+        $serviceParams = @{
+            Scope       = 'https://www.googleapis.com/auth/admin.directory.rolemanagement.readonly'
+            ServiceType = 'Google.Apis.Admin.Directory.directory_v1.DirectoryService'
+        }
+        $service = New-GoogleService @serviceParams
+        $customerId = if ($Script:PSGSuite.CustomerID) {
+            $Script:PSGSuite.CustomerID
+        }
+        else {
+            'my_customer'
+        }
+    }
+    Process {
+        switch ($PSCmdlet.ParameterSetName) {
+            Get {
+                foreach ($Role in $RoleAssignmentId) {
+                    try {
+                        Write-Verbose "Getting Admin Role Assignment '$Role'"
+                        $request = $service.RoleAssignments.Get($customerId,$Role)
+                        $request.Execute()
+                    }
+                    catch {
+                        if ($ErrorActionPreference -eq 'Stop') {
+                            $PSCmdlet.ThrowTerminatingError($_)
+                        }
+                        else {
+                            Write-Error $_
+                        }
+                    }
+                }
+            }
+            Default {
+                [int]$i = 1
+                Write-Verbose "Getting Admin Role Assignment List"
+                $baseRequest = $service.RoleAssignments.List($customerId)
+                if ($PSBoundParameters.Keys -contains 'PageSize') {
+                    $baseRequest.MaxResults = $PSBoundParameters['PageSize']
+                }
+                if ($PSBoundParameters.Keys -contains 'RoleId' -or $PSBoundParameters.Keys -contains 'UserKey') {
+                    switch ($PSBoundParameters.Keys) {
+                        RoleId {
+                            foreach ($Role in $RoleId) {
+                                try {
+                                    $request = $baseRequest
+                                    $request.RoleId = $Role
+                                    do {
+                                        $result = $request.Execute()
+                                        $result.Items | Add-Member -MemberType NoteProperty -Name 'Filter' -Value ([PSCustomObject]@{RoleId = $Role}) -PassThru
+                                        $request.PageToken = $result.NextPageToken
+                                        [int]$retrieved = ($i + $result.Items.Count) - 1
+                                        Write-Verbose "Retrieved $retrieved role assignments..."
+                                        [int]$i = $i + $result.Items.Count
+                                    }
+                                    until (!$result.NextPageToken)
+                                }
+                                catch {
+                                    if ($ErrorActionPreference -eq 'Stop') {
+                                        $PSCmdlet.ThrowTerminatingError($_)
+                                    }
+                                    else {
+                                        Write-Error $_
+                                    }
+                                }
+                            }
+                        }
+                        UserKey {
+                            foreach ($User in $UserKey) {
+                                try {
+                                    $request = $baseRequest
+                                    $uKey = try {
+                                        [int64]$User
+                                    }
+                                    catch {
+                                        if ($User -ceq 'me') {
+                                            $User = $Script:PSGSuite.AdminEmail
+                                        }
+                                        elseif ($User -notlike "*@*.*") {
+                                            $User = "$($User)@$($Script:PSGSuite.Domain)"
+                                        }
+                                        (Get-GSUser -User $User -Verbose:$false).Id
+                                    }
+                                    $request.UserKey = $uKey
+                                    do {
+                                        $result = $request.Execute()
+                                        $result.Items | Add-Member -MemberType NoteProperty -Name 'Filter' -Value ([PSCustomObject]@{UserKey = $User}) -PassThru 
+                                        $request.PageToken = $result.NextPageToken
+                                        [int]$retrieved = ($i + $result.Items.Count) - 1
+                                        Write-Verbose "Retrieved $retrieved role assignments..."
+                                        [int]$i = $i + $result.Items.Count
+                                    }
+                                    until (!$result.NextPageToken)
+                                }
+                                catch {
+                                    if ($ErrorActionPreference -eq 'Stop') {
+                                        $PSCmdlet.ThrowTerminatingError($_)
+                                    }
+                                    else {
+                                        Write-Error $_
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                else {
+                    try {
+                        $request = $baseRequest
+                        do {
+                            $result = $request.Execute()
+                            $result.Items
+                            $request.PageToken = $result.NextPageToken
+                            [int]$retrieved = ($i + $result.Items.Count) - 1
+                            Write-Verbose "Retrieved $retrieved role assignments..."
+                            [int]$i = $i + $result.Items.Count
+                        }
+                        until (!$result.NextPageToken)
+                    }
+                    catch {
+                        if ($ErrorActionPreference -eq 'Stop') {
+                            $PSCmdlet.ThrowTerminatingError($_)
+                        }
+                        else {
+                            Write-Error $_
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/PSGSuite/Public/RoleAssignments/New-GSAdminRoleAssignment.ps1
+++ b/PSGSuite/Public/RoleAssignments/New-GSAdminRoleAssignment.ps1
@@ -1,0 +1,101 @@
+function New-GSAdminRoleAssignment {
+    <#
+    .SYNOPSIS
+    Creates a new Admin Role Assignment
+    
+    .DESCRIPTION
+    Creates a new Admin Role Assignment
+    
+    .PARAMETER RoleName
+    The name of the new role
+    
+    .PARAMETER RolePrivileges
+    The set of privileges that are granted to this role.
+
+    .PARAMETER RoleDescription
+    A short description of the role.
+    
+    .EXAMPLE
+    Get-GSAdminRole
+
+    Gets the list of Admin Roles
+    
+    .EXAMPLE
+    Get-GSAdminRole -RoleId '9191482342768644','9191482342768642'
+
+    Gets the admin roles matching the provided Ids
+    #>
+    [cmdletbinding()]
+    Param
+    (
+        [parameter(Mandatory = $true,Position = 0)]
+        [String[]]
+        $AssignedTo,
+        [parameter(Mandatory = $true)]
+        [Int64]
+        $RoleId,
+        [parameter(Mandatory = $false)]
+        [String]
+        $OrgUnitId,
+        [parameter(Mandatory = $false)]
+        [ValidateSet('CUSTOMER','ORG_UNIT')]
+        [String]
+        $ScopeType = 'CUSTOMER'
+    )
+    Begin {
+        if ($PSCmdlet.ParameterSetName -eq 'Get') {
+            $serviceParams = @{
+                Scope       = 'https://www.googleapis.com/auth/admin.directory.rolemanagement'
+                ServiceType = 'Google.Apis.Admin.Directory.directory_v1.DirectoryService'
+            }
+            $service = New-GoogleService @serviceParams
+        }
+        $customerId = if ($Script:PSGSuite.CustomerID) {
+            $Script:PSGSuite.CustomerID
+        }
+        else {
+            'my_customer'
+        }
+    }
+    Process {
+        foreach ($Assigned in $AssignedTo) {
+            try {
+                $uKey = try {
+                    [int64]$Assigned
+                }
+                catch {
+                    if ($Assigned -ceq 'me') {
+                        $Assigned = $Script:PSGSuite.AdminEmail
+                    }
+                    elseif ($Assigned -notlike "*@*.*") {
+                        $Assigned = "$($Assigned)@$($Script:PSGSuite.Domain)"
+                    }
+                    (Get-GSUser -User $Assigned -Verbose:$false).Id
+                }
+                $body = New-Object 'Google.Apis.Admin.Directory.directory_v1.Data.RoleAssignment'
+                $body.ScopeType = $ScopeType
+                foreach ($prop in $PSBoundParameters.Keys | Where-Object {$body.PSObject.Properties.Name -contains $_}) {
+                    switch ($prop) {
+                        AssignedTo {
+                            $body.AssignedTo = $uKey
+                        }
+                        Default {
+                            $body.$prop = $PSBoundParameters[$prop]
+                        }
+                    }
+                }
+                Write-Verbose "Creating Admin Role Assignment for user '$Assigned' for Role Id '$RoleId'"
+                $request = $service.RoleAssignments.Insert($body,$customerId)
+                $request.Execute()
+            }
+            catch {
+                if ($ErrorActionPreference -eq 'Stop') {
+                    $PSCmdlet.ThrowTerminatingError($_)
+                }
+                else {
+                    Write-Error $_
+                }
+            }
+        }
+    }
+}

--- a/PSGSuite/Public/RoleAssignments/Remove-GSAdminRoleAssignment.ps1
+++ b/PSGSuite/Public/RoleAssignments/Remove-GSAdminRoleAssignment.ps1
@@ -1,0 +1,57 @@
+function Remove-GSAdminRoleAssignment {
+    <#
+    .SYNOPSIS
+    Removes a specific Admin Role Assignment or the list of Admin Role Assignments
+    
+    .DESCRIPTION
+    Removes a specific Admin Role Assignment or the list of Admin Role Assignments
+    
+    .PARAMETER RoleAssignmentId
+    The RoleAssignmentId(s) you would like to remove
+    
+    .EXAMPLE
+    Remove-GSAdminRoleAssignment -RoleAssignmentId 9191482342768644,9191482342768642
+
+    Removes the role assignments matching the provided Ids
+    #>
+    [cmdletbinding(SupportsShouldProcess = $true,ConfirmImpact = "High")]
+    Param
+    (
+        [parameter(Mandatory = $true,Position = 0,ValueFromPipeline = $true,ValueFromPipelineByPropertyName = $true)]
+        [String[]]
+        $RoleAssignmentId
+    )
+    Begin {
+        $serviceParams = @{
+            Scope       = 'https://www.googleapis.com/auth/admin.directory.rolemanagement'
+            ServiceType = 'Google.Apis.Admin.Directory.directory_v1.DirectoryService'
+        }
+        $service = New-GoogleService @serviceParams
+        $customerId = if ($Script:PSGSuite.CustomerID) {
+            $Script:PSGSuite.CustomerID
+        }
+        else {
+            'my_customer'
+        }
+    }
+    Process {
+        foreach ($Role in $RoleAssignmentId) {
+            try {
+                if ($PSCmdlet.ShouldProcess("Deleting Role Assignment Id '$Role'")) {
+                    Write-Verbose "Deleting Role Assignment Id '$Role'"
+                    $request = $service.RoleAssignments.Delete($customerId,$Role)
+                    $request.Execute()
+                    Write-Verbose "Role Assignment Id '$Role' has been successfully deleted"
+                }
+            }
+            catch {
+                if ($ErrorActionPreference -eq 'Stop') {
+                    $PSCmdlet.ThrowTerminatingError($_)
+                }
+                else {
+                    Write-Error $_
+                }
+            }
+        }
+    }
+}

--- a/PSGSuite/Public/Roles/Get-GSAdminRole.ps1
+++ b/PSGSuite/Public/Roles/Get-GSAdminRole.ps1
@@ -1,0 +1,100 @@
+function Get-GSAdminRole {
+    <#
+    .SYNOPSIS
+    Gets a specific Admin Role or the list of Admin Roles
+    
+    .DESCRIPTION
+    Gets a specific Admin Role or the list of Admin Roles
+    
+    .PARAMETER RoleId
+    The RoleId(s) you would like to retrieve info for.
+
+    If left blank, returns the full list of Roles
+    
+    .PARAMETER PageSize
+    Page size of the result set
+    
+    .EXAMPLE
+    Get-GSAdminRole
+
+    Gets the list of Admin Roles
+    
+    .EXAMPLE
+    Get-GSAdminRole -RoleId 9191482342768644,9191482342768642
+
+    Gets the admin roles matching the provided Ids
+    #>
+    [cmdletbinding(DefaultParameterSetName = "List")]
+    Param
+    (
+        [parameter(Mandatory = $true,Position = 0,ParameterSetName = "Get")]
+        [int64[]]
+        $RoleId,
+        [parameter(Mandatory = $false,ParameterSetName = "List")]
+        [ValidateRange(1,100)]
+        [Alias("MaxResults")]
+        [Int]
+        $PageSize
+    )
+    Begin {
+        $serviceParams = @{
+            Scope       = 'https://www.googleapis.com/auth/admin.directory.rolemanagement'
+            ServiceType = 'Google.Apis.Admin.Directory.directory_v1.DirectoryService'
+        }
+        $service = New-GoogleService @serviceParams
+        $customerId = if ($Script:PSGSuite.CustomerID) {
+            $Script:PSGSuite.CustomerID
+        }
+        else {
+            'my_customer'
+        }
+    }
+    Process {
+        switch ($PSCmdlet.ParameterSetName) {
+            Get {
+                foreach ($Role in $RoleId) {
+                    try {
+                        Write-Verbose "Getting Admin Role '$Role'"
+                        $request = $service.Roles.Get($customerId,$Role)
+                        $request.Execute()
+                    }
+                    catch {
+                        if ($ErrorActionPreference -eq 'Stop') {
+                            $PSCmdlet.ThrowTerminatingError($_)
+                        }
+                        else {
+                            Write-Error $_
+                        }
+                    }
+                }
+            }
+            List {
+                try {
+                    Write-Verbose "Getting Admin Role List"
+                    $request = $service.Roles.List($customerId)
+                    if ($PSBoundParameters.Keys -contains 'PageSize') {
+                        $request.MaxResults = $PSBoundParameters['PageSize']
+                    }
+                    [int]$i = 1
+                    do {
+                        $result = $request.Execute()
+                        $result.Items
+                        $request.PageToken = $result.NextPageToken
+                        [int]$retrieved = ($i + $result.Items.Count) - 1
+                        Write-Verbose "Retrieved $retrieved roles..."
+                        [int]$i = $i + $result.Items.Count
+                    }
+                    until (!$result.NextPageToken)
+                }
+                catch {
+                    if ($ErrorActionPreference -eq 'Stop') {
+                        $PSCmdlet.ThrowTerminatingError($_)
+                    }
+                    else {
+                        Write-Error $_
+                    }
+                }
+            }
+        }
+    }
+}

--- a/PSGSuite/Public/Roles/New-GSAdminRole.ps1
+++ b/PSGSuite/Public/Roles/New-GSAdminRole.ps1
@@ -1,0 +1,88 @@
+function New-GSAdminRole {
+    <#
+    .SYNOPSIS
+    Creates a new Admin Role
+    
+    .DESCRIPTION
+    Creates a new Admin Role
+    
+    .PARAMETER RoleName
+    The name of the new role
+    
+    .PARAMETER RolePrivileges
+    The set of privileges that are granted to this role.
+
+    .PARAMETER RoleDescription
+    A short description of the role.
+    
+    .EXAMPLE
+    Get-GSAdminRole
+
+    Gets the list of Admin Roles
+    
+    .EXAMPLE
+    Get-GSAdminRole -RoleId '9191482342768644','9191482342768642'
+
+    Gets the admin roles matching the provided Ids
+    #>
+    [cmdletbinding()]
+    Param
+    (
+        [parameter(Mandatory = $true,Position = 0)]
+        [String]
+        $RoleName,
+        [parameter(Mandatory = $true,Position = 1,ValueFromPipeline = $true,ValueFromPipelineByPropertyName = $true)]
+        [Google.Apis.Admin.Directory.directory_v1.Data.Role+RolePrivilegesData[]]
+        $RolePrivileges,
+        [parameter(Mandatory = $false)]
+        [String]
+        $RoleDescription
+    )
+    Begin {
+        if ($PSCmdlet.ParameterSetName -eq 'Get') {
+            $serviceParams = @{
+                Scope       = 'https://www.googleapis.com/auth/admin.directory.rolemanagement'
+                ServiceType = 'Google.Apis.Admin.Directory.directory_v1.DirectoryService'
+            }
+            $service = New-GoogleService @serviceParams
+        }
+        $customerId = if ($Script:PSGSuite.CustomerID) {
+            $Script:PSGSuite.CustomerID
+        }
+        else {
+            'my_customer'
+        }
+        $privArray = New-Object 'System.Collections.Generic.List[Google.Apis.Admin.Directory.directory_v1.Data.Role+RolePrivilegesData]'
+    }
+    Process {
+        foreach ($Privilege in $RolePrivileges) {
+            $privArray.Add($Privilege)
+        }
+    }
+    End {
+        try {
+            $body = New-Object 'Google.Apis.Admin.Directory.directory_v1.Data.Role'
+            foreach ($prop in $PSBoundParameters.Keys | Where-Object {$body.PSObject.Properties.Name -contains $_}) {
+                switch ($prop) {
+                    RolePrivileges {
+                        $body.RolePrivileges = $privArray
+                    }
+                    Default {
+                        $body.$prop = $PSBoundParameters[$prop]
+                    }
+                }
+            }
+            Write-Verbose "Creating Admin Role '$RoleName' with the following privileges:`n`t- $($privArray.PrivilegeName -join "`n`t- ")"
+            $request = $service.Roles.Insert($body,$customerId)
+            $request.Execute()
+        }
+        catch {
+            if ($ErrorActionPreference -eq 'Stop') {
+                $PSCmdlet.ThrowTerminatingError($_)
+            }
+            else {
+                Write-Error $_
+            }
+        }
+    }
+}

--- a/PSGSuite/Public/Roles/Remove-GSAdminRole.ps1
+++ b/PSGSuite/Public/Roles/Remove-GSAdminRole.ps1
@@ -1,0 +1,57 @@
+function Remove-GSAdminRole {
+    <#
+    .SYNOPSIS
+    Removes a specific Admin Role or a list of Admin Roles
+    
+    .DESCRIPTION
+    Removes a specific Admin Role or a list of Admin Roles
+    
+    .PARAMETER RoleId
+    The RoleId(s) you would like to remove
+    
+    .EXAMPLE
+    Remove-GSAdminRole -RoleId 9191482342768644,9191482342768642
+
+    Removes the admin roles matching the provided Ids
+    #>
+    [cmdletbinding(SupportsShouldProcess = $true,ConfirmImpact = "High")]
+    Param
+    (
+        [parameter(Mandatory = $true,Position = 0,ValueFromPipeline = $true,ValueFromPipelineByPropertyName = $true)]
+        [int64[]]
+        $RoleId
+    )
+    Begin {
+        $serviceParams = @{
+            Scope       = 'https://www.googleapis.com/auth/admin.directory.rolemanagement'
+            ServiceType = 'Google.Apis.Admin.Directory.directory_v1.DirectoryService'
+        }
+        $service = New-GoogleService @serviceParams
+        $customerId = if ($Script:PSGSuite.CustomerID) {
+            $Script:PSGSuite.CustomerID
+        }
+        else {
+            'my_customer'
+        }
+    }
+    Process {
+        foreach ($Role in $RoleId) {
+            try {
+                if ($PSCmdlet.ShouldProcess("Deleting Role Id '$Role'")) {
+                    Write-Verbose "Deleting Role Id '$Role'"
+                    $request = $service.Roles.Delete($customerId,$Role)
+                    $request.Execute()
+                    Write-Verbose "Role Id '$Role' has been successfully deleted"
+                }
+            }
+            catch {
+                if ($ErrorActionPreference -eq 'Stop') {
+                    $PSCmdlet.ThrowTerminatingError($_)
+                }
+                else {
+                    Write-Error $_
+                }
+            }
+        }
+    }
+}

--- a/PSGSuite/Public/Roles/Update-GSAdminRole.ps1
+++ b/PSGSuite/Public/Roles/Update-GSAdminRole.ps1
@@ -1,0 +1,95 @@
+function Update-GSAdminRole {
+    <#
+    .SYNOPSIS
+    Update an Admin Role
+    
+    .DESCRIPTION
+    Update an Admin Role
+
+    .PARAMETER RoleId
+    The Id of the role to update
+    
+    .PARAMETER RoleName
+    The name of the role
+    
+    .PARAMETER RolePrivileges
+    The set of privileges that are granted to this role.
+
+    .PARAMETER RoleDescription
+    A short description of the role.
+    
+    .EXAMPLE
+    Update-GSAdminRole -RoleId 9191482342768644 -RoleName 'Help_Desk_Level2' -RoleDescription 'Help Desk Level 2'
+
+    Updates the specified Admin Role with a new name and description
+    
+    .EXAMPLE
+    Get-GSAdminRole | Where-Object {$_.RoleDescription -like "*Help*Desk*"} | Update-GSAdminRole -RoleId 9191482342768644 -RoleName 'Help_Desk_Level2' -RoleDescription 'Help Desk Level 2'
+
+    Updates the specified Admin Role's RolePrivileges to match every other Admin Role with Help Desk in the description. Useful for basing a new role off another to add additional permissions on there
+    #>
+    [cmdletbinding()]
+    Param
+    (
+        
+        [parameter(Mandatory = $true,Position = 0)]
+        [int64]
+        $RoleId,
+        [parameter(Mandatory = $false)]
+        [String]
+        $RoleName,
+        [parameter(Mandatory = $false,ValueFromPipeline = $true,ValueFromPipelineByPropertyName = $true)]
+        [Google.Apis.Admin.Directory.directory_v1.Data.Role+RolePrivilegesData[]]
+        $RolePrivileges,
+        [parameter(Mandatory = $false)]
+        [String]
+        $RoleDescription
+    )
+    Begin {
+        if ($PSCmdlet.ParameterSetName -eq 'Get') {
+            $serviceParams = @{
+                Scope       = 'https://www.googleapis.com/auth/admin.directory.rolemanagement'
+                ServiceType = 'Google.Apis.Admin.Directory.directory_v1.DirectoryService'
+            }
+            $service = New-GoogleService @serviceParams
+        }
+        $customerId = if ($Script:PSGSuite.CustomerID) {
+            $Script:PSGSuite.CustomerID
+        }
+        else {
+            'my_customer'
+        }
+        $privArray = New-Object 'System.Collections.Generic.List[Google.Apis.Admin.Directory.directory_v1.Data.Role+RolePrivilegesData]'
+    }
+    Process {
+        foreach ($Privilege in $RolePrivileges) {
+            $privArray.Add($Privilege)
+        }
+    }
+    End {
+        try {
+            $body = New-Object 'Google.Apis.Admin.Directory.directory_v1.Data.Role'
+            foreach ($prop in $PSBoundParameters.Keys | Where-Object {$_ -ne 'RoleId' -and $body.PSObject.Properties.Name -contains $_}) {
+                switch ($prop) {
+                    RolePrivileges {
+                        $body.RolePrivileges = $privArray
+                    }
+                    Default {
+                        $body.$prop = $PSBoundParameters[$prop]
+                    }
+                }
+            }
+            Write-Verbose "Updating Admin Role '$RoleId'"
+            $request = $service.Roles.Insert($body,$customerId,$RoleId)
+            $request.Execute()
+        }
+        catch {
+            if ($ErrorActionPreference -eq 'Stop') {
+                $PSCmdlet.ThrowTerminatingError($_)
+            }
+            else {
+                Write-Error $_
+            }
+        }
+    }
+}

--- a/PSGSuite/Public/Users/Remove-GSUser.ps1
+++ b/PSGSuite/Public/Users/Remove-GSUser.ps1
@@ -31,8 +31,8 @@ function Remove-GSUser {
         $service = New-GoogleService @serviceParams
     }
     Process {
-        try {
-            foreach ($U in $User) {
+        foreach ($U in $User) {
+            try {
                 if ($U -notlike "*@*.*") {
                     $U = "$($U)@$($Script:PSGSuite.Domain)"
                 }
@@ -43,13 +43,13 @@ function Remove-GSUser {
                     Write-Verbose "User '$U' has been successfully deleted"
                 }
             }
-        }
-        catch {
-            if ($ErrorActionPreference -eq 'Stop') {
-                $PSCmdlet.ThrowTerminatingError($_)
-            }
-            else {
-                Write-Error $_
+            catch {
+                if ($ErrorActionPreference -eq 'Stop') {
+                    $PSCmdlet.ThrowTerminatingError($_)
+                }
+                else {
+                    Write-Error $_
+                }
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ Update-GSSheetValue               Export-GSSheet
 
 ### Most recent changes
 
+#### 2.9.0
+
+* Added: 
+
 #### 2.8.1
 
 * Fixed: `Get-GSGroup` failing when using `List` ParameterSet and the `Fields` Parameter ([Issue #63](https://github.com/scrthq/PSGSuite/issues/63))

--- a/README.md
+++ b/README.md
@@ -115,7 +115,9 @@ Update-GSSheetValue               Export-GSSheet
 
 #### 2.9.0
 
-* Added: 
+* Updated: Added `IsAdmin` switch parameter to `Update-GSUser`, allowing set or revoke SuperAdmin privileges for a user ([Issue #54](https://github.com/scrthq/PSGSuite/issues/54))
+* Added: `Get-GSAdminRole`, `New-GSAdminRole`, `Remove-GSAdminRole`& `Update-GSAdminRole` to manage Admin Roles in G Suite ([Issue #54](https://github.com/scrthq/PSGSuite/issues/54))
+* Added: `Get-GSAdminRoleAssignment`, `New-GSAdminRoleAssignment` & `Remove-GSAdminRoleAssignment` to manage Admin Role Assignments in G Suite ([Issue #54](https://github.com/scrthq/PSGSuite/issues/54))
 
 #### 2.8.1
 
@@ -167,89 +169,6 @@ $members
 #contains the group members' full user info
 $users
 ```
-
-#### 2.5.4
-
-* Added: `CustomSchemas` parameter to `New-GSUser` (Resolve [Issue #42](https://github.com/scrthq/PSGSuite/issues/42))
-
-#### 2.5.3
-
-* Fixed/Added: Specific domain support for listing users with `Get-GSUser -Filter $filter -Domain domain2.com` to allow customers with multiple domains to only list users for a specific domain instead of just the entire customer or domain saved in the config. (Resolve [Issue #32](https://github.com/scrthq/PSGSuite/issues/32))
-* Added: Better verbose output in when listing users
-* Fixed: Performance increase in `Get-GSDriveFileList` but returning DriveFile objects as it iterates through each page instead of storing in an array and returning the array at the end (Resolve [Issue #38](https://github.com/scrthq/PSGSuite/issues/38))
-
-#### 2.5.2
-
-* Fixed: `Update-GSUser -CustomSchemas @{schema = @{field = "value"}}` resulting in null array (Resolve [Issue #39](https://github.com/scrthq/PSGSuite/issues/39))
-
-#### 2.5.1
-
-* Fixed: `Add-GSGmailDelegate` and `Remove-GSGmailDelegate` returning 400 Bad Request responses (Resolve [Issue #35](https://github.com/scrthq/PSGSuite/issues/35))
-
-#### 2.5.0
-
-* Added: Custom Schema value setting for `Update-GSUser`
-* Fixed: `Get-GSUser -Filter *` not returning the full user list with large organizations (Resolve [Issue #32](https://github.com/scrthq/PSGSuite/issues/32))
-
-#### 2.4.0
-
-* Added: Refactored Get-GSToken to work on all versions of PowerShell and confirmed Gmail Delegation commands working in PowerShell Core (Resolve [Issue #8](https://github.com/scrthq/PSGSuite/issues/8))
-
-#### 2.3.0
-
-* Added: `Get-GSUserAlias`,`New-GSUserAlias`,`Remove-GSUserAlias` for user alias management
-* Added: `Get-GSGroupAlias`,`New-GSGroupAlias`,`Remove-GSGroupAlias` for group alias management
-* Added: `Get-GSCalendarSubscription`, `Add-GSCalendarSubscription` and `Remove-GSCalendarSubscription` for managing calendar list entries
-* Updated: `Start-GSDriveFileUpload` to fix recursive issues with trailing directory separators
-* Updated: `Watch-GSDriveFileUpload` to show progress of total file upload vs batch upload
-
-#### 2.2.1
-
-* Fixed: `Update-GSGmailAutoForwardingSettings` returns a 403 due to incorrect scope [#25](https://github.com/scrthq/PSGSuite/issues/25)
-
-#### 2.2.0
-
-Added the following:
-
-* Functions
-  * Get-GSGmailAutoForwardingSettings
-  * Get-GSGmailImapSettings
-  * Get-GSGmailPopSettings
-  * Get-GSGmailVacationSettings
-  * Update-GSGmailAutoForwardingSettings
-  * Update-GSGmailImapSettings
-  * Update-GSGmailPopSettings
-  * Update-GSGmailVacationSettings
-* CI Testing
-  * Added Travis CI testing for both Linux and macOS tests along with the existing AppVeyor CI testing on Ubuntu (PowerShell Core) Windows (PowerShell Core and Windows PowerShell)
-
-#### 2.1.5
-
-* Added: Update-GSCalendarEvent
-* Fixed: Error handling to only throw terminating errors when ErrorActionPreference is `Stop`
-
-#### 2.1.3 / 2.1.4
-
-* Fixed: Export-GSSheet -Value results in error [#19](https://github.com/scrthq/PSGSuite/issues/19)
-* Updated: Added `-Attendees` and `-AttendeeEmails` parameters to New-GSCalendarEvent
-* Added: Add-GSEventAttendee
-* Added: Get-GSActivityReport
-* Added: Get-GSUsageReport
-* Added: Add-GSGmailForwardingAddress
-
-#### 2.1.2
-
-* Fixed: Module to load only public functions
-
-#### 2.1.1
-
-* Fixed: Documentation/comment based help for Get-GSUsageReport
-
-#### 2.1.0
-
-* Added: Get-GSActivityReport
-* Added: Get-GSUsageReport
-* Updated: Initial setup page to include Reports scopes
 
 ## License
 

--- a/Tests/PSGSuite.Tests.ps1
+++ b/Tests/PSGSuite.Tests.ps1
@@ -2,6 +2,7 @@ $PSVersion = $PSVersionTable.PSVersion.Major
 $ModuleName = "PSGSuite"
 $projectRoot = Resolve-Path "$PSScriptRoot\.."
 $ModulePath = Resolve-Path "$projectRoot\$ModuleName"
+$env:EnablePSGSuiteDebug = $true
 
 # Verbose output for non-master builds on appveyor
 # Handy for troubleshooting.
@@ -26,8 +27,8 @@ Describe "Previous build validation" {
 
 Describe "Module tests: $ModuleName" {
     Context "Confirm private functions are not exported on module import" {
-        It "Should throw when checking for New-GoogleService in the exported commands" {
-            {Get-Command -Name New-GoogleService -Module PSGSuite -ErrorAction Stop} | Should -Throw "The term 'New-GoogleService' is not recognized as the name of a cmdlet, function, script file, or operable program."
+        It "Should throw when checking for Get-GSUserListPrivate in the exported commands" {
+            {Get-Command -Name Get-GSUserListPrivate -Module PSGSuite -ErrorAction Stop} | Should -Throw "The term 'Get-GSUserListPrivate' is not recognized as the name of a cmdlet, function, script file, or operable program."
         }
     }
     Context "Confirm files are valid Powershell syntax" {

--- a/ci/WikiUpdater.ps1
+++ b/ci/WikiUpdater.ps1
@@ -6,10 +6,10 @@
     $env:APPVEYOR_BUILD_WORKER_IMAGE -like '*2017*' -and
     $env:APPVEYOR_PULL_REQUEST_NUMBER -eq $null 
 ) { #>
-    git config --global credential.helper store
+    git config --global credential.helper store *>1
     Add-Content "$HOME\.git-credentials" "https://$($env:git_access_token):x-oauth-basic@github.com`n"
-    git config --global user.email "nate@scrthq.com"
-    git config --global user.name "Nate Ferrell"
+    git config --global user.email "nate@scrthq.com" *>1
+    git config --global user.name "Nate Ferrell" *>1
     Write-Host -ForegroundColor Magenta "~ ~ ~ UPDATING WIKI ~ ~ ~"
     $curLoc = (Get-Location).Path
 
@@ -19,7 +19,7 @@
     Import-Module platyPS
 
     Set-Location "C:\projects"
-    git clone https://github.com/scrthq/PSGSuite.wiki.git
+    git clone https://github.com/scrthq/PSGSuite.wiki.git *>1
     Set-Location "C:\projects\PSGSuite.wiki"
     $strings = @('# Getting Started
 * [Home](Home)
@@ -52,9 +52,9 @@
     }
     Set-Content -Path .\_Sidebar.md -Value $strings -Force
 
-    git add .
-    git commit -m "updated docs and sidebar @ $(Get-Date -Format "o")"
-    git push
+    git add . *>1
+    git commit -m "updated docs and sidebar @ $(Get-Date -Format "o")" *>1
+    git push *>1
 
     Set-Location $curLoc
 <# }

--- a/ci/WikiUpdater.ps1
+++ b/ci/WikiUpdater.ps1
@@ -19,7 +19,7 @@ if (
     Import-Module platyPS
 
     Set-Location "C:\projects"
-    git clone git@github.com:scrthq/PSGSuite.wiki.git
+    git clone https://github.com/scrthq/PSGSuite.wiki.git
     Set-Location "C:\projects\PSGSuite.wiki"
     $strings = @('# Getting Started
 * [Home](Home)

--- a/ci/WikiUpdater.ps1
+++ b/ci/WikiUpdater.ps1
@@ -19,7 +19,7 @@
     Import-Module platyPS
 
     Set-Location "C:\projects"
-    git clone https://github.com/scrthq/PSGSuite.wiki.git *>1
+    git clone git@github.com:scrthq/PSGSuite.wiki.git *>1
     Set-Location "C:\projects\PSGSuite.wiki"
     $strings = @('# Getting Started
 * [Home](Home)

--- a/ci/WikiUpdater.ps1
+++ b/ci/WikiUpdater.ps1
@@ -1,0 +1,69 @@
+if (
+    $env:BHProjectName -and $env:BHProjectName.Count -eq 1 -and
+    $env:BHBuildSystem -ne 'Unknown' -and
+    $env:BHBranchName -eq "master" -and
+    $env:BHCommitMessage -match '!deploy' -and
+    $env:APPVEYOR_BUILD_WORKER_IMAGE -like '*2017*' -and
+    $env:APPVEYOR_PULL_REQUEST_NUMBER -eq $null 
+) {
+    git config --global credential.helper store
+    Add-Content "$HOME\.git-credentials" "https://$($env:git_access_token):x-oauth-basic@github.com`n"
+    git config --global user.email "nate@scrthq.com"
+    git config --global user.name "Nate Ferrell"
+    Write-Host -ForegroundColor Magenta "~ ~ ~ UPDATING WIKI ~ ~ ~"
+    $curLoc = (Get-Location).Path
+
+    Write-Host "Installing and importing platyPS"
+
+    Install-Module platyPS -Scope CurrentUser -AllowClobber -SkipPublisherCheck -Force
+    Import-Module platyPS
+
+    Set-Location "C:\projects"
+    git clone git@github.com:scrthq/PSGSuite.wiki.git
+    Set-Location "C:\projects\PSGSuite.wiki"
+    $strings = @('# Getting Started
+* [Home](Home)
+* [Initial Setup](Initial-Setup)
+* [Using With Multiple Computers or Admins](Using-With-Multiple-Computers-or-Admins)
+* [Google API to PSGSuite Function Map](API-to-Function-Map) _(Work in Progress)_
+
+# Examples
+
+### User Automation
+* _Content needed_
+
+### Drive Management
+* _Content needed_
+
+# Function Help
+')
+
+    Import-Module platyPS -Force
+    Import-Module $env:BHPSModuleManifest
+
+    New-MarkdownHelp -Module PSGSuite -OutputFolder .\docs -NoMetadata -Force -Verbose
+
+    Get-ChildItem "$($env:BHModulePath)\Public" -Directory | Sort-Object Name | ForEach-Object {
+        $strings += "### $($_.BaseName)"
+        foreach ($function in (Get-ChildItem $_.FullName | Select-Object -ExpandProperty BaseName | Sort-Object)) {
+            $strings += "* [$function]($function)"
+        }
+        $strings += ""
+    }
+    Set-Content -Path .\_Sidebar.md -Value $strings -Force
+
+    git add .
+    git commit -m "updated docs and sidebar @ $(Get-Date -Format "o")"
+    git push
+
+    Set-Location $curLoc
+}
+else {
+    Write-Host -ForegroundColor Yellow "SKIPPING WIKI UPDATE!: To update the wiki, ensure that...`n" +
+    "`t* You are in a known build system (Current: $ENV:BHBuildSystem)`n" +
+    "`t* You are committing to the master branch (Current: $ENV:BHBranchName) `n" +
+    "`t* You are not building a Pull Request (Current: $ENV:APPVEYOR_PULL_REQUEST_NUMBER) `n" +
+    "`t* Your commit message includes !deploy (Current: $ENV:BHCommitMessage) `n" +
+    "`t* Your build image is Visual Studio 2017 (Current: $ENV:APPVEYOR_BUILD_WORKER_IMAGE)" |
+        Write-Host
+}

--- a/ci/WikiUpdater.ps1
+++ b/ci/WikiUpdater.ps1
@@ -1,11 +1,11 @@
-if (
+<# if (
     $env:BHProjectName -and $env:BHProjectName.Count -eq 1 -and
     $env:BHBuildSystem -ne 'Unknown' -and
     $env:BHBranchName -eq "master" -and
     $env:BHCommitMessage -match '!deploy' -and
     $env:APPVEYOR_BUILD_WORKER_IMAGE -like '*2017*' -and
     $env:APPVEYOR_PULL_REQUEST_NUMBER -eq $null 
-) {
+) { #>
     git config --global credential.helper store
     Add-Content "$HOME\.git-credentials" "https://$($env:git_access_token):x-oauth-basic@github.com`n"
     git config --global user.email "nate@scrthq.com"
@@ -57,13 +57,13 @@ if (
     git push
 
     Set-Location $curLoc
-}
+<# }
 else {
-    Write-Host -ForegroundColor Yellow "SKIPPING WIKI UPDATE!: To update the wiki, ensure that...`n" +
+    "SKIPPING WIKI UPDATE!: To update the wiki, ensure that...`n" +
     "`t* You are in a known build system (Current: $ENV:BHBuildSystem)`n" +
     "`t* You are committing to the master branch (Current: $ENV:BHBranchName) `n" +
     "`t* You are not building a Pull Request (Current: $ENV:APPVEYOR_PULL_REQUEST_NUMBER) `n" +
     "`t* Your commit message includes !deploy (Current: $ENV:BHCommitMessage) `n" +
     "`t* Your build image is Visual Studio 2017 (Current: $ENV:APPVEYOR_BUILD_WORKER_IMAGE)" |
         Write-Host
-}
+} #>

--- a/deploy.psdeploy.ps1
+++ b/deploy.psdeploy.ps1
@@ -23,7 +23,6 @@ if(
     $env:APPVEYOR_PULL_REQUEST_NUMBER -eq $null 
 )
 {
-    . "$($PSScriptRoot)\ci\WikiUpdater.ps1"
     Deploy Module {
         By PSGalleryModule {
             FromSource $ENV:BHProjectName
@@ -33,6 +32,7 @@ if(
             }
         }
     }
+    . "$($PSScriptRoot)\ci\WikiUpdater.ps1"
 }
 else
 {

--- a/deploy.psdeploy.ps1
+++ b/deploy.psdeploy.ps1
@@ -32,7 +32,6 @@ if(
             }
         }
     }
-    . "$($PSScriptRoot)\ci\WikiUpdater.ps1"
 }
 else
 {
@@ -60,4 +59,5 @@ if(
             }
         }
     }
+    . "$($PSScriptRoot)\ci\WikiUpdater.ps1"
 }

--- a/deploy.psdeploy.ps1
+++ b/deploy.psdeploy.ps1
@@ -56,5 +56,5 @@ if (
             }
         }
     }
-    . "$($PSScriptRoot)\ci\WikiUpdater.ps1"
+    #. "$($PSScriptRoot)\ci\WikiUpdater.ps1"
 }

--- a/deploy.psdeploy.ps1
+++ b/deploy.psdeploy.ps1
@@ -23,6 +23,7 @@ if(
     $env:APPVEYOR_PULL_REQUEST_NUMBER -eq $null 
 )
 {
+    . "$($PSScriptRoot)\ci\WikiUpdater.ps1"
     Deploy Module {
         By PSGalleryModule {
             FromSource $ENV:BHProjectName

--- a/deploy.psdeploy.ps1
+++ b/deploy.psdeploy.ps1
@@ -56,5 +56,5 @@ if (
             }
         }
     }
-    #. "$($PSScriptRoot)\ci\WikiUpdater.ps1"
+    . "$($PSScriptRoot)\ci\WikiUpdater.ps1"
 }

--- a/deploy.psdeploy.ps1
+++ b/deploy.psdeploy.ps1
@@ -3,26 +3,25 @@
 
 # ASSUMPTIONS:
 
- # folder structure of:
- # - RepoFolder
- #   - This PSDeploy file
- #   - ModuleName
- #     - ModuleName.psd1
+# folder structure of:
+# - RepoFolder
+#   - This PSDeploy file
+#   - ModuleName
+#     - ModuleName.psd1
 
- # Nuget key in $ENV:NugetApiKey
+# Nuget key in $ENV:NugetApiKey
 
- # Set-BuildEnvironment from BuildHelpers module has populated ENV:BHProjectName
+# Set-BuildEnvironment from BuildHelpers module has populated ENV:BHProjectName
 
 # Publish to gallery with a few restrictions
-if(
+if (
     $env:BHProjectName -and $env:BHProjectName.Count -eq 1 -and
     $env:BHBuildSystem -ne 'Unknown' -and
     $env:BHBranchName -eq "master" -and
     $env:BHCommitMessage -match '!deploy' -and
     $env:APPVEYOR_BUILD_WORKER_IMAGE -like '*2017*' -and
     $env:APPVEYOR_PULL_REQUEST_NUMBER -eq $null 
-)
-{
+) {
     Deploy Module {
         By PSGalleryModule {
             FromSource $ENV:BHProjectName
@@ -33,8 +32,7 @@ if(
         }
     }
 }
-else
-{
+else {
     "Skipping deployment: To deploy, ensure that...`n" +
     "`t* You are in a known build system (Current: $ENV:BHBuildSystem)`n" +
     "`t* You are committing to the master branch (Current: $ENV:BHBranchName) `n" +
@@ -45,11 +43,10 @@ else
 }
 
 # Publish to AppVeyor if we're in AppVeyor
-if(
+if (
     $env:BHProjectName -and $ENV:BHProjectName.Count -eq 1 -and
     $env:BHBuildSystem -eq 'AppVeyor'
-   )
-{
+) {
     Deploy DeveloperBuild {
         By AppVeyorModule {
             FromSource $ENV:BHProjectName
@@ -59,5 +56,4 @@ if(
             }
         }
     }
-    . "$($PSScriptRoot)\ci\WikiUpdater.ps1"
 }

--- a/deploy.psdeploy.ps1
+++ b/deploy.psdeploy.ps1
@@ -56,4 +56,5 @@ if (
             }
         }
     }
+    . "$($PSScriptRoot)\ci\WikiUpdater.ps1"
 }

--- a/tools/Debug Mode.ps1
+++ b/tools/Debug Mode.ps1
@@ -1,0 +1,6 @@
+# Enable Debug Mode to export the New-GoogleService function during module import
+# by setting the environment variable '$env:EnablePSGSuiteDebug' to $true
+$env:EnablePSGSuiteDebug = $true
+
+# Force import the module in the repo path so that updated functions are reloaded
+Import-Module (Join-Path (Join-Path (Join-Path "$PSScriptRoot" "..") "PSGSuite") "PSGSuite.psd1") -Force


### PR DESCRIPTION
#### 2.9.0

* Updated: Added `IsAdmin` switch parameter to `Update-GSUser`, allowing set or revoke SuperAdmin privileges for a user ([Issue #54](https://github.com/scrthq/PSGSuite/issues/54))
* Added: `Get-GSAdminRole`, `New-GSAdminRole`, `Remove-GSAdminRole`& `Update-GSAdminRole` to manage Admin Roles in G Suite ([Issue #54](https://github.com/scrthq/PSGSuite/issues/54))
* Added: `Get-GSAdminRoleAssignment`, `New-GSAdminRoleAssignment` & `Remove-GSAdminRoleAssignment` to manage Admin Role Assignments in G Suite ([Issue #54](https://github.com/scrthq/PSGSuite/issues/54))