### PR TITLE
!build v2.10.1 add Path param to Update-GSDriveFile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ TestPad.ps1
 **.insyncdl
 .vscode
 API-to-Function-Map.md
-
+QueueExample.ps1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- TOC -->
 
 - [Changelog](#changelog)
+  - [2.10.1](#2101)
   - [2.10.0](#2100)
   - [2.9.0](#290)
   - [2.8.1](#281)
@@ -39,6 +40,10 @@
       - [Functions Aliased](#functions-aliased)
 
 <!-- /TOC -->
+
+## 2.10.1
+
+* Updated: Added `Path` parameter to `Update-GSDriveFile` to allow updating a file's contents in Drive using a local file path.
 
 ## 2.10.0
 

--- a/PSGSuite/PSGSuite.psd1
+++ b/PSGSuite/PSGSuite.psd1
@@ -12,7 +12,7 @@
     RootModule            = 'PSGSuite.psm1'
 
     # Version number of this module.
-    ModuleVersion         = '2.10.0'
+    ModuleVersion         = '2.10.1'
 
     # ID used to uniquely identify this module
     GUID                  = '9d751152-e83e-40bb-a6db-4c329092aaec'

--- a/PSGSuite/Public/Drive/Update-GSDriveFile.ps1
+++ b/PSGSuite/Public/Drive/Update-GSDriveFile.ps1
@@ -133,6 +133,8 @@ function Update-GSDriveFile {
                 }
                 $stream = New-Object 'System.IO.FileStream' $ioFile.FullName,'Open','Read'
                 $request = $service.Files.Update($body,$FileId,$stream,$contentType)
+                $request.QuotaUser = $User
+                $request.ChunkSize = 512KB
             }
             else {
                 $request = $service.Files.Update($body,$FileId)

--- a/PSGSuite/Public/Drive/Update-GSDriveFile.ps1
+++ b/PSGSuite/Public/Drive/Update-GSDriveFile.ps1
@@ -9,8 +9,8 @@ function Update-GSDriveFile {
     .PARAMETER FileId
     The unique Id of the Drive file to Update
     
-    .PARAMETER User
-    The email or unique Id of the Drive file owner
+    .PARAMETER Path
+    The path to the local file whose content you would like to upload to Drive.
     
     .PARAMETER Name
     The new name of the Drive file
@@ -36,10 +36,18 @@ function Update-GSDriveFile {
     .PARAMETER Fields
     The specific fields to returned
     
+    .PARAMETER User
+    The email or unique Id of the Drive file owner
+    
     .EXAMPLE
     Update-GSDriveFile -FileId '1rhsAYTOB_vrpvfwImPmWy0TcVa2sgmQa_9u976' -Name "To-Do Progress"
 
     Updates the Drive file with a new name, "To-Do Progress"
+    
+    .EXAMPLE
+    Update-GSDriveFile -FileId '1rhsAYTOB_vrpvfwImPmWy0TcVa2sgmQa_9u976' -Path "C:\Pics\NewPic.png"
+
+    Updates the Drive file with the content of the file at that path. In this example, the Drive file is a PNG named "Test.png". This will change the content of the file in Drive to match NewPic.png as well as rename it to "NewPic.png"
     #>
     [cmdletbinding(DefaultParameterSetName = "Depth")]
     Param
@@ -48,10 +56,10 @@ function Update-GSDriveFile {
         [Alias('Id')]
         [String]
         $FileId,
-        [parameter(Mandatory = $false,ValueFromPipelineByPropertyName = $true)]
-        [Alias('Owner','PrimaryEmail','UserKey','Mail')]
-        [string]
-        $User = $Script:PSGSuite.AdminEmail,
+        [parameter(Mandatory = $false,Position = 1)]
+        [ValidateScript({Test-Path $_})]
+        [String]
+        $Path,
         [parameter(Mandatory = $false)]
         [String]
         $Name,
@@ -72,7 +80,11 @@ function Update-GSDriveFile {
         [parameter(Mandatory = $false,ParameterSetName = "Fields")]
         [ValidateSet("appProperties","capabilities","contentHints","createdTime","description","explicitlyTrashed","fileExtension","folderColorRgb","fullFileExtension","hasThumbnail","headRevisionId","iconLink","id","imageMediaMetadata","isAppAuthorized","kind","lastModifyingUser","md5Checksum","mimeType","modifiedByMe","modifiedByMeTime","modifiedTime","name","originalFilename","ownedByMe","owners","parents","permissions","properties","quotaBytesUsed","shared","sharedWithMeTime","sharingUser","size","spaces","starred","thumbnailLink","thumbnailVersion","trashed","version","videoMediaMetadata","viewedByMe","viewedByMeTime","viewersCanCopyContent","webContentLink","webViewLink","writersCanShare")]
         [String[]]
-        $Fields
+        $Fields,
+        [parameter(Mandatory = $false,ValueFromPipelineByPropertyName = $true)]
+        [Alias('Owner','PrimaryEmail','UserKey','Mail')]
+        [string]
+        $User = $Script:PSGSuite.AdminEmail
     )
     Begin {
         if ($Projection) {
@@ -113,7 +125,18 @@ function Update-GSDriveFile {
             if ($Description) {
                 $body.Description = $Description
             }
-            $request = $service.Files.Update($body,$FileId)
+            if ($PSBoundParameters.Keys -contains 'Path') {
+                $ioFile = Get-Item $Path
+                $contentType = Get-MimeType $ioFile
+                if ($PSBoundParameters.Keys -notcontains 'Name') {
+                    $body.Name = $ioFile.Name
+                }
+                $stream = New-Object 'System.IO.FileStream' $ioFile.FullName,'Open','Read'
+                $request = $service.Files.Update($body,$FileId,$stream,$contentType)
+            }
+            else {
+                $request = $service.Files.Update($body,$FileId)
+            }
             $request.SupportsTeamDrives = $true
             if ($fs) {
                 $request.Fields = $($fs -join ",")
@@ -125,7 +148,13 @@ function Update-GSDriveFile {
                 $request.RemoveParents = $($RemoveParents -join ",")
             }
             Write-Verbose "Updating file '$FileId' for user '$User'"
-            $request.Execute() | Add-Member -MemberType NoteProperty -Name 'User' -Value $User -PassThru
+            if ($PSBoundParameters.Keys -contains 'Path') {
+                $request.Upload()
+                $stream.Close()
+            }
+            else {
+                $request.Execute() | Add-Member -MemberType NoteProperty -Name 'User' -Value $User -PassThru
+            }
         }
         catch {
             if ($ErrorActionPreference -eq 'Stop') {

--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ Update-GSSheetValue               Export-GSSheet
 
 ### Most recent changes
 
+#### 2.10.1
+
+* Updated: Added `Path` parameter to `Update-GSDriveFile` to allow updating a file's contents in Drive using a local file path.
+
 #### 2.10.0
 
 * Added: `Clear-GSTasklist`, `Get-GSTask`, `Get-GSTasklist`, `Move-GSTask`, `New-GSTask`, `New-GSTasklist`, `Remove-GSTask`, `Remove-GSTasklist`, `Update-GSTask` & `Update-GSTasklist`


### PR DESCRIPTION
## 2.10.1

* Updated: Added `Path` parameter to `Update-GSDriveFile` to allow updating a file's contents in Drive using a local file path.