### PR TITLE
!build v2.10.2 add *-GSDocContent functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- TOC -->
 
 - [Changelog](#changelog)
+  - [2.10.2](#2102)
   - [2.10.1](#2101)
   - [2.10.0](#2100)
   - [2.9.0](#290)
@@ -41,9 +42,13 @@
 
 <!-- /TOC -->
 
+## 2.10.2
+
+* Added: `Get-GSDocContent`, `Set-GSDocContent` & `Add-GSDocContent` to establish functional parity with `Get-Content`, `Set-Content` & `Add-Content` in regards to working with Google Docs ([Issue #56](https://github.com/scrthq/PSGSuite/issues/56))
+
 ## 2.10.1
 
-* Updated: Added `Path` parameter to `Update-GSDriveFile` to allow updating a file's contents in Drive using a local file path.
+* Updated: Added `Path` parameter to `Update-GSDriveFile` to allow updating a file's contents in Drive using a local file path ([Issue #55](https://github.com/scrthq/PSGSuite/issues/55))
 
 ## 2.10.0
 

--- a/PSGSuite/PSGSuite.psd1
+++ b/PSGSuite/PSGSuite.psd1
@@ -12,7 +12,7 @@
     RootModule            = 'PSGSuite.psm1'
 
     # Version number of this module.
-    ModuleVersion         = '2.10.1'
+    ModuleVersion         = '2.10.2'
 
     # ID used to uniquely identify this module
     GUID                  = '9d751152-e83e-40bb-a6db-4c329092aaec'

--- a/PSGSuite/Public/Drive/Add-GSDocContent.ps1
+++ b/PSGSuite/Public/Drive/Add-GSDocContent.ps1
@@ -1,0 +1,86 @@
+function Add-GSDocContent {
+    <#
+    .SYNOPSIS
+    Adds content to a Google Doc via appending new text. This does not overwrite existing content
+    
+    .DESCRIPTION
+    Adds content to a Google Doc via appending new text. This does not overwrite existing content
+    
+    .PARAMETER FileID
+    The unique Id of the file to add content to
+    
+    .PARAMETER Value
+    The content to add
+    
+    .PARAMETER User
+    The email or unique Id of the owner of the Drive file
+
+    Defaults to the AdminEmail user
+    
+    .EXAMPLE
+    $newLogStrings | Add-GSDocContent -FileId '1rhsAYTOB_vrpvfwImPmWy0TcVa2sgmQa_9u976'
+
+    Appends the strings in the $newLogStrings variable to the existing the content of the specified Google Doc.
+    #>
+    [CmdLetBinding()]
+    Param
+    (      
+        [parameter(Mandatory = $true,Position = 0)]
+        [String]
+        $FileID,
+        [parameter(Mandatory = $true,ValueFromPipeline = $true)]
+        [String[]]
+        $Value,
+        [parameter(Mandatory = $false,ValueFromPipelineByPropertyName = $true)]
+        [Alias('Owner','PrimaryEmail','UserKey','Mail')]
+        [string]
+        $User = $Script:PSGSuite.AdminEmail
+    )
+    Begin {
+        if ($User -ceq 'me') {
+            $User = $Script:PSGSuite.AdminEmail
+        }
+        elseif ($User -notlike "*@*.*") {
+            $User = "$($User)@$($Script:PSGSuite.Domain)"
+        }
+        $serviceParams = @{
+            Scope       = 'https://www.googleapis.com/auth/drive'
+            ServiceType = 'Google.Apis.Drive.v3.DriveService'
+            User        = $User
+        }
+        $service = New-GoogleService @serviceParams
+        $stream = New-Object 'System.IO.MemoryStream'
+        $writer = New-Object 'System.IO.StreamWriter' $stream
+        $currentContent = Get-GSDocContent -FileID $FileID -User $User -Verbose:$false
+        $concatStrings = @($currentContent)
+    }
+    Process {
+        foreach ($string in $Value) {
+            $concatStrings += $string
+        }
+    }
+    End {
+        try {
+            $concatStrings = $concatStrings -join "`n"
+            $writer.Write($concatStrings)
+            $writer.Flush()
+            $contentType = 'text/plain'
+            $body = New-Object 'Google.Apis.Drive.v3.Data.File'
+            $request = $service.Files.Update($body,$FileId,$stream,$contentType)
+            $request.QuotaUser = $User
+            $request.ChunkSize = 512KB
+            $request.SupportsTeamDrives = $true
+            Write-Verbose "Adding content to File '$FileID'"
+            $request.Upload() | Out-Null
+            $stream.Close()
+        }
+        catch {
+            if ($ErrorActionPreference -eq 'Stop') {
+                $PSCmdlet.ThrowTerminatingError($_)
+            }
+            else {
+                Write-Error $_
+            }
+        }
+    }
+}

--- a/PSGSuite/Public/Drive/Export-GSDriveFile.ps1
+++ b/PSGSuite/Public/Drive/Export-GSDriveFile.ps1
@@ -51,7 +51,7 @@ function Export-GSDriveFile {
     The specific fields to returned
     
     .EXAMPLE
-    Export-GSDriveFile -FileId '1rhsAYTOB_vrpvfwImPmWy0TcVa2sgmQa_9u976' -Type CSV
+    Export-GSDriveFile -FileId '1rhsAYTOB_vrpvfwImPmWy0TcVa2sgmQa_9u976' -Type CSV -OutFilePath .\SheetExport.csv
 
     Exports the Drive file as a CSV to the current working directory
     #>
@@ -153,6 +153,7 @@ function Export-GSDriveFile {
                 }
             }
             else {
+                Write-Verbose "Getting content of File '$FileID' as Type '$Type'"
                 $request.Execute()
             }
         }

--- a/PSGSuite/Public/Drive/Get-GSDocContent.ps1
+++ b/PSGSuite/Public/Drive/Get-GSDocContent.ps1
@@ -1,0 +1,57 @@
+function Get-GSDocContent {
+    <#
+    .SYNOPSIS
+    Gets the content of a Google Doc and returns it as an array of strings. Supports HTML or PlainText
+    
+    .DESCRIPTION
+    Gets the content of a Google Doc and returns it as an array of strings. Supports HTML or PlainText
+    
+    .PARAMETER FileID
+    The unique Id of the file to get content of
+    
+    .PARAMETER User
+    The email or unique Id of the owner of the Drive file
+
+    Defaults to the AdminEmail user
+    
+    .EXAMPLE
+    Get-GSDocContent -FileId '1rhsAYTOB_vrpvfwImPmWy0TcVa2sgmQa_9u976'
+
+    Exports the Drive file as a CSV to the current working directory
+    #>
+    [CmdLetBinding()]
+    Param
+    (      
+        [parameter(Mandatory = $true,Position = 0)]
+        [String]
+        $FileID,
+        [parameter(Mandatory = $false,ValueFromPipelineByPropertyName = $true)]
+        [Alias('Owner','PrimaryEmail','UserKey','Mail')]
+        [string]
+        $User = $Script:PSGSuite.AdminEmail,
+        [parameter(Mandatory = $false)]
+        [ValidateSet("HTML","PlainText")]
+        [String]
+        $Type
+    )
+    Begin {
+        $typeParam = @{}
+        if ($PSBoundParameters.Keys -notcontains 'Type') {
+            $typeParam['Type'] = "PlainText"
+        }
+    }
+    Process {
+        try {
+            (Export-GSDriveFile @PSBoundParameters -Projection Minimal @typeParam) -split "`n"
+            Write-Verbose "Content retrieved for File '$FileID'"
+        }
+        catch {
+            if ($ErrorActionPreference -eq 'Stop') {
+                $PSCmdlet.ThrowTerminatingError($_)
+            }
+            else {
+                Write-Error $_
+            }
+        }
+    }
+}

--- a/PSGSuite/Public/Drive/Set-GSDocContent.ps1
+++ b/PSGSuite/Public/Drive/Set-GSDocContent.ps1
@@ -1,0 +1,85 @@
+function Set-GSDocContent {
+    <#
+    .SYNOPSIS
+    Sets the content of a Google Doc. This overwrites any existing content on the Doc
+    
+    .DESCRIPTION
+    Sets the content of a Google Doc. This overwrites any existing content on the Doc
+    
+    .PARAMETER FileID
+    The unique Id of the file to set content on
+    
+    .PARAMETER Value
+    The content to set
+    
+    .PARAMETER User
+    The email or unique Id of the owner of the Drive file
+
+    Defaults to the AdminEmail user
+    
+    .EXAMPLE
+    $logStrings | Set-GSDocContent -FileId '1rhsAYTOB_vrpvfwImPmWy0TcVa2sgmQa_9u976'
+
+    Sets the content of the specified Google Doc to the strings in the $logStrings variable. Any existing content on the doc will be overwritten.
+    #>
+    [CmdLetBinding()]
+    Param
+    (      
+        [parameter(Mandatory = $true,Position = 0)]
+        [String]
+        $FileID,
+        [parameter(Mandatory = $true,ValueFromPipeline = $true)]
+        [String[]]
+        $Value,
+        [parameter(Mandatory = $false,ValueFromPipelineByPropertyName = $true)]
+        [Alias('Owner','PrimaryEmail','UserKey','Mail')]
+        [string]
+        $User = $Script:PSGSuite.AdminEmail
+    )
+    Begin {
+        if ($User -ceq 'me') {
+            $User = $Script:PSGSuite.AdminEmail
+        }
+        elseif ($User -notlike "*@*.*") {
+            $User = "$($User)@$($Script:PSGSuite.Domain)"
+        }
+        $serviceParams = @{
+            Scope       = 'https://www.googleapis.com/auth/drive'
+            ServiceType = 'Google.Apis.Drive.v3.DriveService'
+            User        = $User
+        }
+        $service = New-GoogleService @serviceParams
+        $stream = New-Object 'System.IO.MemoryStream'
+        $writer = New-Object 'System.IO.StreamWriter' $stream
+        $concatStrings = @()
+    }
+    Process {
+        foreach ($string in $Value) {
+            $concatStrings += $string
+        }
+    }
+    End {
+        try {
+            $concatStrings = $concatStrings -join "`n"
+            $writer.Write($concatStrings)
+            $writer.Flush()
+            $contentType = 'text/plain'
+            $body = New-Object 'Google.Apis.Drive.v3.Data.File'
+            $request = $service.Files.Update($body,$FileId,$stream,$contentType)
+            $request.QuotaUser = $User
+            $request.ChunkSize = 512KB
+            $request.SupportsTeamDrives = $true
+            Write-Verbose "Setting content for File '$FileID'"
+            $request.Upload() | Out-Null
+            $stream.Close()
+        }
+        catch {
+            if ($ErrorActionPreference -eq 'Stop') {
+                $PSCmdlet.ThrowTerminatingError($_)
+            }
+            else {
+                Write-Error $_
+            }
+        }
+    }
+}

--- a/PSGSuite/Public/Drive/Update-GSDriveFile.ps1
+++ b/PSGSuite/Public/Drive/Update-GSDriveFile.ps1
@@ -151,7 +151,7 @@ function Update-GSDriveFile {
             }
             Write-Verbose "Updating file '$FileId' for user '$User'"
             if ($PSBoundParameters.Keys -contains 'Path') {
-                $request.Upload()
+                $request.Upload() | Out-Null
                 $stream.Close()
             }
             else {

--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ Update-GSSheetValue               Export-GSSheet
 
 ### Most recent changes
 
+#### 2.10.2
+
+* Added: `Get-GSDocContent`, `Set-GSDocContent` & `Add-GSDocContent` to establish functional parity with `Get-Content`, `Set-Content` & `Add-Content` in regards to working with Google Docs ([Issue #56](https://github.com/scrthq/PSGSuite/issues/56))
+
 #### 2.10.1
 
 * Updated: Added `Path` parameter to `Update-GSDriveFile` to allow updating a file's contents in Drive using a local file path.


### PR DESCRIPTION
## 2.10.2

* Added: `Get-GSDocContent`, `Set-GSDocContent` & `Add-GSDocContent` to establish functional parity with `Get-Content`, `Set-Content` & `Add-Content` in regards to working with Google Docs ([Issue #56](https://github.com/scrthq/PSGSuite/issues/56))