### PR TITLE
!build v2.11.0 S/MIME info functions to resolve #57

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- TOC -->
 
 - [Changelog](#changelog)
+  - [2.11.0](#2110)
   - [2.10.2](#2102)
   - [2.10.1](#2101)
   - [2.10.0](#2100)
@@ -41,6 +42,10 @@
       - [Functions Aliased](#functions-aliased)
 
 <!-- /TOC -->
+
+## 2.11.0
+
+* Added: `Get-GSGmailSMIMEInfo`, `Remove-GSGmailSMIMEInfo` & `New-GSGmailSMIMEInfo` to get, delete and insert S/MIME info for a user, respectively ([Issue #57](https://github.com/scrthq/PSGSuite/issues/57))
 
 ## 2.10.2
 

--- a/PSGSuite/PSGSuite.psd1
+++ b/PSGSuite/PSGSuite.psd1
@@ -12,7 +12,7 @@
     RootModule            = 'PSGSuite.psm1'
 
     # Version number of this module.
-    ModuleVersion         = '2.10.2'
+    ModuleVersion         = '2.11.0'
 
     # ID used to uniquely identify this module
     GUID                  = '9d751152-e83e-40bb-a6db-4c329092aaec'

--- a/PSGSuite/Public/Drive/Remove-GSDrivePermission.ps1
+++ b/PSGSuite/Public/Drive/Remove-GSDrivePermission.ps1
@@ -27,7 +27,7 @@ function Remove-GSDrivePermission {
 
     Gets the permissions assigned to groups and removes them.
     #>
-    [cmdletbinding(ConfirmImpact = "High")]
+    [cmdletbinding(SupportsShouldProcess = $true,ConfirmImpact = "High")]
     Param
     (
         [parameter(Mandatory = $false,Position = 0,ValueFromPipelineByPropertyName = $true)]
@@ -58,11 +58,12 @@ function Remove-GSDrivePermission {
     }
     Process {
         try {
-            $request = $service.Permissions.Delete($FileId,$PermissionId)
-            $request.SupportsTeamDrives = $true
-            $request.Execute()
-            Write-Verbose "Successfully removed Drive Permission Id '$PermissionId' from FileId '$FileID'"
-            
+            if ($PSCmdlet.ShouldProcess("Removing Drive Permission Id '$PermissionId' from FileId '$FileID'")) {
+                $request = $service.Permissions.Delete($FileId,$PermissionId)
+                $request.SupportsTeamDrives = $true
+                $request.Execute()
+                Write-Verbose "Successfully removed Drive Permission Id '$PermissionId' from FileId '$FileID'"
+            }
         }
         catch {
             if ($ErrorActionPreference -eq 'Stop') {

--- a/PSGSuite/Public/Gmail/Get-GSGmailFilter.ps1
+++ b/PSGSuite/Public/Gmail/Get-GSGmailFilter.ps1
@@ -4,7 +4,7 @@ function Get-GSGmailFilter {
     Gets Gmail filter details
     
     .DESCRIPTION
-    Long description
+    Gets Gmail filter details
     
     .PARAMETER FilterId
     The unique Id of the filter you would like to retrieve information for. If excluded, all filters for the user are returned

--- a/PSGSuite/Public/Gmail/Get-GSGmailSMIMEInfo.ps1
+++ b/PSGSuite/Public/Gmail/Get-GSGmailSMIMEInfo.ps1
@@ -1,0 +1,82 @@
+function Get-GSGmailSMIMEInfo {
+    <#
+    .SYNOPSIS
+    Gets Gmail S/MIME info
+    
+    .DESCRIPTION
+    Gets Gmail S/MIME info
+    
+    .PARAMETER SendAsEmail
+    The email address that appears in the "From:" header for mail sent using this alias.
+    
+    .PARAMETER Id
+    The immutable ID for the SmimeInfo.
+
+    If left blank, returns the list of S/MIME infos for the SendAsEmail and User
+    
+    .PARAMETER User
+    The user's email address
+
+    Defaults to the AdminEmail user
+    
+    .EXAMPLE
+    Get-GSGmailSMIMEInfo -SendAsEmail 'joe@otherdomain.com' -User joe@domain.com
+
+    Gets the list of S/MIME infos for Joe's SendAsEmail 'joe@otherdomain.com'
+    #>
+    [cmdletbinding()]
+    Param
+    (
+        [parameter(Mandatory = $true)]
+        [string]
+        $SendAsEmail,
+        [parameter(Mandatory = $false)]
+        [string[]]
+        $Id,
+        [parameter(Mandatory = $false,Position = 0,ValueFromPipelineByPropertyName = $true)]
+        [Alias("PrimaryEmail","UserKey","Mail")]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $User = $Script:PSGSuite.AdminEmail
+    )
+    Begin {
+        if ($User -ceq 'me') {
+            $User = $Script:PSGSuite.AdminEmail
+        }
+        elseif ($User -notlike "*@*.*") {
+            $User = "$($User)@$($Script:PSGSuite.Domain)"
+        }
+        $serviceParams = @{
+            Scope       = 'https://www.googleapis.com/auth/gmail.settings.basic'
+            ServiceType = 'Google.Apis.Gmail.v1.GmailService'
+            User        = $User
+        }
+        $service = New-GoogleService @serviceParams
+    }
+    Process {
+        try {
+            switch ($PSCmdlet.ParameterSetName) {
+                Get {
+                    foreach ($I in $Id) {
+                        $request = $service.Users.Settings.SendAs.SmimeInfo.Get($User,$SendAsEmail,$I)
+                        Write-Verbose "Getting S/MIME Id '$I' of SendAsEmail '$SendAsEmail' for user '$User'"
+                        $request.Execute() | Add-Member -MemberType NoteProperty -Name 'User' -Value $User -PassThru
+                    }
+                }
+                List {
+                    $request = $service.Users.Settings.SendAs.SmimeInfo.List($User,$SendAsEmail)
+                    Write-Verbose "Getting list of S/MIME Id's of SendAsEmail '$SendAsEmail' for user '$User'"
+                    $request.Execute() | Select-Object -ExpandProperty smimeInfo | Add-Member -MemberType NoteProperty -Name 'User' -Value $User -PassThru
+                }
+            }
+        }
+        catch {
+            if ($ErrorActionPreference -eq 'Stop') {
+                $PSCmdlet.ThrowTerminatingError($_)
+            }
+            else {
+                Write-Error $_
+            }
+        }
+    }
+}

--- a/PSGSuite/Public/Gmail/Get-GSGmailSMIMEInfo.ps1
+++ b/PSGSuite/Public/Gmail/Get-GSGmailSMIMEInfo.ps1
@@ -30,10 +30,10 @@ function Get-GSGmailSMIMEInfo {
         [parameter(Mandatory = $true)]
         [string]
         $SendAsEmail,
-        [parameter(Mandatory = $false)]
+        [parameter(Mandatory = $false,ValueFromPipelineByPropertyName = $true)]
         [string[]]
         $Id,
-        [parameter(Mandatory = $false,Position = 0,ValueFromPipelineByPropertyName = $true)]
+        [parameter(Mandatory = $false)]
         [Alias("PrimaryEmail","UserKey","Mail")]
         [ValidateNotNullOrEmpty()]
         [string]
@@ -55,19 +55,17 @@ function Get-GSGmailSMIMEInfo {
     }
     Process {
         try {
-            switch ($PSCmdlet.ParameterSetName) {
-                Get {
-                    foreach ($I in $Id) {
-                        $request = $service.Users.Settings.SendAs.SmimeInfo.Get($User,$SendAsEmail,$I)
-                        Write-Verbose "Getting S/MIME Id '$I' of SendAsEmail '$SendAsEmail' for user '$User'"
-                        $request.Execute() | Add-Member -MemberType NoteProperty -Name 'User' -Value $User -PassThru
-                    }
+            if ($PSBoundParameters.Keys -contains 'Id') {
+                foreach ($I in $Id) {
+                    $request = $service.Users.Settings.SendAs.SmimeInfo.Get($User,$SendAsEmail,$I)
+                    Write-Verbose "Getting S/MIME Id '$I' of SendAsEmail '$SendAsEmail' for user '$User'"
+                    $request.Execute() | Add-Member -MemberType NoteProperty -Name 'User' -Value $User -PassThru
                 }
-                List {
-                    $request = $service.Users.Settings.SendAs.SmimeInfo.List($User,$SendAsEmail)
-                    Write-Verbose "Getting list of S/MIME Id's of SendAsEmail '$SendAsEmail' for user '$User'"
-                    $request.Execute() | Select-Object -ExpandProperty smimeInfo | Add-Member -MemberType NoteProperty -Name 'User' -Value $User -PassThru
-                }
+            }
+            else {
+                $request = $service.Users.Settings.SendAs.SmimeInfo.List($User,$SendAsEmail)
+                Write-Verbose "Getting list of S/MIME Id's of SendAsEmail '$SendAsEmail' for user '$User'"
+                $request.Execute() | Select-Object -ExpandProperty smimeInfo | Add-Member -MemberType NoteProperty -Name 'User' -Value $User -PassThru
             }
         }
         catch {

--- a/PSGSuite/Public/Gmail/New-GSGmailSMIMEInfo.ps1
+++ b/PSGSuite/Public/Gmail/New-GSGmailSMIMEInfo.ps1
@@ -1,0 +1,105 @@
+function New-GSGmailSMIMEInfo {
+    <#
+    .SYNOPSIS
+    Adds Gmail S/MIME info
+    
+    .DESCRIPTION
+    Adds Gmail S/MIME info
+    
+    .PARAMETER SendAsEmail
+    The email address that appears in the "From:" header for mail sent using this alias.
+    
+    .PARAMETER Pkcs12
+    PKCS#12 format containing a single private/public key pair and certificate chain. This format is only accepted from client for creating a new SmimeInfo and is never returned, because the private key is not intended to be exported. PKCS#12 may be encrypted, in which case encryptedKeyPassword should be set appropriately.
+    
+    .PARAMETER EncryptedKeyPassword
+    Encrypted key password, when key is encrypted.
+
+    .PARAMETER IsDefault
+    Whether this SmimeInfo is the default one for this user's send-as address.
+    
+    .PARAMETER User
+    The user's email address
+    
+    .EXAMPLE
+    New-GSGmailSMIMEInfo -SendAsEmail 'joe@otherdomain.com' -Pkcs12 .\MyCert.pfx -User joe@domain.com
+
+    Creates a specified S/MIME for Joe's SendAsEmail 'joe@otherdomain.com' using the provided PKCS12 certificate
+    #>
+    [cmdletbinding()]
+    Param
+    (
+        [parameter(Mandatory = $true,ValueFromPipelineByPropertyName = $true)]
+        [string]
+        $SendAsEmail,
+        [parameter(Mandatory = $true)]
+        [ValidateScript({
+            if (!(Test-Path $_)) {
+                throw "Please enter a valid file path."
+            }
+            elseif ($_ -notlike "*.pfx" -and $_ -notlike "*.p12") {
+                throw "Pkcs12 must be a .pfx or .p12 file"
+            }
+            else {
+                $true
+            }
+        })]
+        [string]
+        $Pkcs12,
+        [parameter(Mandatory = $false)]
+        [SecureString]
+        $EncryptedKeyPassword,
+        [parameter(Mandatory = $false)]
+        [Switch]
+        $IsDefault,
+        [parameter(Mandatory = $true)]
+        [Alias("PrimaryEmail","UserKey","Mail")]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $User
+    )
+    Begin {
+        if ($User -ceq 'me') {
+            $User = $Script:PSGSuite.AdminEmail
+        }
+        elseif ($User -notlike "*@*.*") {
+            $User = "$($User)@$($Script:PSGSuite.Domain)"
+        }
+        $serviceParams = @{
+            Scope       = 'https://www.googleapis.com/auth/gmail.settings.basic'
+            ServiceType = 'Google.Apis.Gmail.v1.GmailService'
+            User        = $User
+        }
+        $service = New-GoogleService @serviceParams
+    }
+    Process {
+        try {
+            $body = New-Object 'Google.Apis.Gmail.v1.Data.SmimeInfo'
+            foreach ($key in $PSBoundParameters.Keys | Where-Object {$body.PSObject.Properties.Name -contains $_}) {
+                switch ($key) {
+                    EncryptedKeyPassword {
+                        $body.$key = (New-Object PSCredential "user",$PSBoundParameters[$key]).GetNetworkCredential().Password
+                    }
+                    Pkcs12 {
+                        $p12String = Convert-Base64 -From NormalString -To WebSafeBase64String -String "$([System.IO.File]::ReadAllText((Resolve-Path $PSBoundParameters[$key]).Path))"
+                        $body.$key = $p12String
+                    }
+                    Default {
+                        $body.$prop = $PSBoundParameters[$prop]
+                    }
+                }
+            }
+            Write-Verbose "Adding new S/MIME of SendAsEmail '$SendAsEmail' for user '$User' using Certificate '$Pkcs12'"
+            $request = $service.Users.Settings.SendAs.SmimeInfo.Insert($body,$User,$SendAsEmail)
+            $request.Execute() | Add-Member -MemberType NoteProperty -Name 'User' -Value $User -PassThru
+        }
+        catch {
+            if ($ErrorActionPreference -eq 'Stop') {
+                $PSCmdlet.ThrowTerminatingError($_)
+            }
+            else {
+                Write-Error $_
+            }
+        }
+    }
+}

--- a/PSGSuite/Public/Gmail/Remove-GSGmailSMIMEInfo.ps1
+++ b/PSGSuite/Public/Gmail/Remove-GSGmailSMIMEInfo.ps1
@@ -1,0 +1,73 @@
+function Remove-GSGmailSMIMEInfo {
+    <#
+    .SYNOPSIS
+    Removes Gmail S/MIME info
+    
+    .DESCRIPTION
+    Removes Gmail S/MIME info
+    
+    .PARAMETER SendAsEmail
+    The email address that appears in the "From:" header for mail sent using this alias.
+    
+    .PARAMETER Id
+    The immutable ID for the SmimeInfo
+    
+    .PARAMETER User
+    The user's email address
+
+    Defaults to the AdminEmail user
+    
+    .EXAMPLE
+    Remove-GSGmailSMIMEInfo -SendAsEmail 'joe@otherdomain.com' -Id 1008396210820120578939 -User joe@domain.com
+
+    Rmoves the specified S/MIME info for Joe's SendAsEmail 'joe@otherdomain.com'
+    #>
+    [cmdletbinding(SupportsShouldProcess = $true,ConfirmImpact = "High")]
+    Param
+    (
+        [parameter(Mandatory = $true,ValueFromPipelineByPropertyName = $true)]
+        [string]
+        $SendAsEmail,
+        [parameter(Mandatory = $true,ValueFromPipelineByPropertyName = $true)]
+        [string[]]
+        $Id,
+        [parameter(Mandatory = $false)]
+        [Alias("PrimaryEmail","UserKey","Mail")]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $User = $Script:PSGSuite.AdminEmail
+    )
+    Begin {
+        if ($User -ceq 'me') {
+            $User = $Script:PSGSuite.AdminEmail
+        }
+        elseif ($User -notlike "*@*.*") {
+            $User = "$($User)@$($Script:PSGSuite.Domain)"
+        }
+        $serviceParams = @{
+            Scope       = 'https://www.googleapis.com/auth/gmail.settings.basic'
+            ServiceType = 'Google.Apis.Gmail.v1.GmailService'
+            User        = $User
+        }
+        $service = New-GoogleService @serviceParams
+    }
+    Process {
+        foreach ($I in $Id) {
+            try {
+                if ($PSCmdlet.ShouldProcess("Removing S/MIME Id '$I' of SendAsEmail '$SendAsEmail' for user '$User'")) {
+                    $request = $service.Users.Settings.SendAs.SmimeInfo.Delete($User,$SendAsEmail,$I)
+                    $request.Execute()
+                    Write-Verbose "Successfully removed S/MIME Id '$I' of SendAsEmail '$SendAsEmail' for user '$User'"
+                }
+            }
+            catch {
+                if ($ErrorActionPreference -eq 'Stop') {
+                    $PSCmdlet.ThrowTerminatingError($_)
+                }
+                else {
+                    Write-Error $_
+                }
+            }
+        }
+    }
+}

--- a/PSGSuite/Public/Gmail/Remove-GSGmailSMIMEInfo.ps1
+++ b/PSGSuite/Public/Gmail/Remove-GSGmailSMIMEInfo.ps1
@@ -20,7 +20,7 @@ function Remove-GSGmailSMIMEInfo {
     .EXAMPLE
     Remove-GSGmailSMIMEInfo -SendAsEmail 'joe@otherdomain.com' -Id 1008396210820120578939 -User joe@domain.com
 
-    Rmoves the specified S/MIME info for Joe's SendAsEmail 'joe@otherdomain.com'
+    Removes the specified S/MIME info for Joe's SendAsEmail 'joe@otherdomain.com'.
     #>
     [cmdletbinding(SupportsShouldProcess = $true,ConfirmImpact = "High")]
     Param

--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ Update-GSSheetValue               Export-GSSheet
 
 ### Most recent changes
 
+#### 2.11.0
+
+* Added: `Get-GSGmailSMIMEInfo`, `Remove-GSGmailSMIMEInfo` & `New-GSGmailSMIMEInfo` to get, delete and insert S/MIME info for a user, respectively ([Issue #57](https://github.com/scrthq/PSGSuite/issues/57))
+
 #### 2.10.2
 
 * Added: `Get-GSDocContent`, `Set-GSDocContent` & `Add-GSDocContent` to establish functional parity with `Get-Content`, `Set-Content` & `Add-Content` in regards to working with Google Docs ([Issue #56](https://github.com/scrthq/PSGSuite/issues/56))

--- a/Tests/PSGSuite.Tests.ps1
+++ b/Tests/PSGSuite.Tests.ps1
@@ -70,17 +70,14 @@ Describe "Module tests: $ModuleName" {
 Describe "Function contents" {
     Context "All non-helper public functions should use Write-Verbose" {
         $scripts = Get-ChildItem "$ModulePath\Public" -Include *.ps1 -Recurse | Where-Object {$_.FullName -notlike "*Helpers*"}
-
         $testCase = $scripts | Foreach-Object {@{file = $_;Name = $_.BaseName}}         
         It "Function <Name> should contain verbose output" -TestCases $testCase {
             param($file,$Name)
-
             $file.fullname | Should -FileContentMatch 'Write-Verbose'
         }
     }
     Context "All 'Remove' functions should SupportsShouldProcess" {
         $scripts = Get-ChildItem "$ModulePath\Public" -Include 'Remove-*.ps1' -Recurse | Where-Object {$_.FullName -notlike "*Helpers*"}
-
         $testCase = $scripts | Foreach-Object {@{file = $_;Name = $_.BaseName}}
         It "Function <Name> should contain SupportsShouldProcess" -TestCases $testCase {
             param($file,$Name)
@@ -88,6 +85,8 @@ Describe "Function contents" {
         }
     }
     Context "All 'Remove' functions should contain 'PSCmdlet.ShouldProcess'" {
+        $scripts = Get-ChildItem "$ModulePath\Public" -Include 'Remove-*.ps1' -Recurse | Where-Object {$_.FullName -notlike "*Helpers*"}
+        $testCase = $scripts | Foreach-Object {@{file = $_;Name = $_.BaseName}}    
         It "Function <Name> should contain PSCmdlet.ShouldProcess" -TestCases $testCase {
             param($file,$Name)
             $file.fullname | Should -FileContentMatch 'PSCmdlet.ShouldProcess'

--- a/Tests/PSGSuite.Tests.ps1
+++ b/Tests/PSGSuite.Tests.ps1
@@ -78,4 +78,14 @@ Describe "Function contents" {
             $file.fullname | Should -FileContentMatch 'Write-Verbose'
         }
     }
+    Context "All 'Remove' functions should SupportsShouldProcess" {
+        $scripts = Get-ChildItem "$ModulePath\Public" -Include 'Remove-*.ps1' -Recurse | Where-Object {$_.FullName -notlike "*Helpers*"}
+
+        $testCase = $scripts | Foreach-Object {@{file = $_;Name = $_.BaseName}}         
+        It "Function <Name> should contain SupportsShouldProcess" -TestCases $testCase {
+            param($file,$Name)
+            $file.fullname | Should -FileContentMatch 'SupportsShouldProcess'
+            $file.fullname | Should -FileContentMatch '$PSCmdlet.ShouldProcess'
+        }
+    }
 }

--- a/Tests/PSGSuite.Tests.ps1
+++ b/Tests/PSGSuite.Tests.ps1
@@ -85,7 +85,7 @@ Describe "Function contents" {
         It "Function <Name> should contain SupportsShouldProcess" -TestCases $testCase {
             param($file,$Name)
             $file.fullname | Should -FileContentMatch 'SupportsShouldProcess'
-            $file.fullname | Should -FileContentMatch '$PSCmdlet.ShouldProcess'
+            $file.fullname | Should -FileContentMatch 'PSCmdlet.ShouldProcess'
         }
     }
 }

--- a/Tests/PSGSuite.Tests.ps1
+++ b/Tests/PSGSuite.Tests.ps1
@@ -81,10 +81,13 @@ Describe "Function contents" {
     Context "All 'Remove' functions should SupportsShouldProcess" {
         $scripts = Get-ChildItem "$ModulePath\Public" -Include 'Remove-*.ps1' -Recurse | Where-Object {$_.FullName -notlike "*Helpers*"}
 
-        $testCase = $scripts | Foreach-Object {@{file = $_;Name = $_.BaseName}}         
+        $testCase = $scripts | Foreach-Object {@{file = $_;Name = $_.BaseName}}
         It "Function <Name> should contain SupportsShouldProcess" -TestCases $testCase {
             param($file,$Name)
             $file.fullname | Should -FileContentMatch 'SupportsShouldProcess'
+        }
+        It "Function <Name> should contain PSCmdlet.ShouldProcess" -TestCases $testCase {
+            param($file,$Name)
             $file.fullname | Should -FileContentMatch 'PSCmdlet.ShouldProcess'
         }
     }

--- a/Tests/PSGSuite.Tests.ps1
+++ b/Tests/PSGSuite.Tests.ps1
@@ -87,9 +87,10 @@ Describe "Function contents" {
             $file.fullname | Should -FileContentMatch 'SupportsShouldProcess'
         }
     }
-    Context "All 'Remove' functions should contain 'PSCmdlet.ShouldProcess'"
+    Context "All 'Remove' functions should contain 'PSCmdlet.ShouldProcess'" {
         It "Function <Name> should contain PSCmdlet.ShouldProcess" -TestCases $testCase {
             param($file,$Name)
             $file.fullname | Should -FileContentMatch 'PSCmdlet.ShouldProcess'
         }
+    }
 }

--- a/Tests/PSGSuite.Tests.ps1
+++ b/Tests/PSGSuite.Tests.ps1
@@ -86,9 +86,10 @@ Describe "Function contents" {
             param($file,$Name)
             $file.fullname | Should -FileContentMatch 'SupportsShouldProcess'
         }
+    }
+    Context "All 'Remove' functions should contain 'PSCmdlet.ShouldProcess'"
         It "Function <Name> should contain PSCmdlet.ShouldProcess" -TestCases $testCase {
             param($file,$Name)
             $file.fullname | Should -FileContentMatch 'PSCmdlet.ShouldProcess'
         }
-    }
 }


### PR DESCRIPTION
## 2.11.0

* Added: `Get-GSGmailSMIMEInfo`, `Remove-GSGmailSMIMEInfo` & `New-GSGmailSMIMEInfo` to get, delete and insert S/MIME info for a user, respectively ([Issue #57](https://github.com/scrthq/PSGSuite/issues/57))