### PR TITLE
 !build v2.15.3 with updates for #87 and #93

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,13 +54,15 @@
 * [Issue #87](https://github.com/scrthq/PSGSuite/issues/87)
   * Fixed `Add-GSCourseParticipant` error: `"Cannot convert the "student@uni.edu" value of type "System.String" to type "Google.Apis.Classroom.v1.Data.Student"."`
   * Set `$request.Fields = "*"` for `Get-GSCourseParticipant` and `Get-GSClassroomUserProfile` to return all available fields for the `Profile`, including `EmailAddress`
+* [Issue #93](https://github.com/scrthq/PSGSuite/issues/93)
+  * Added: `MaxToModify` parameter to `Remove-GSGmailMessage` and `Update-GSGmailMessageLabels` in the `Filter` parameter set to prevent removing/updating more messages than expected when using a filter to gather the list of messages to update.
 * Added: `Id` alias for `User` parameter on `Get-GSUser` for better pipeline support
 
 ## 2.15.2
 
 * [Pull Request #94](https://github.com/scrthq/PSGSuite/pull/94) **Thanks, [@dwrusse](https://github.com/dwrusse)!**
   * Added `Update-GSGmailLabel` to enable updating of Gmail label properties
-  * Added `Update-GSGmailMessageLabel` enable updating of labels attached to Gmail messages
+  * Added `Update-GSGmailMessageLabels` enable updating of labels attached to Gmail messages
 * [Issue #93](https://github.com/scrthq/PSGSuite/issues/93)
   * Updated `Remove-GSGmailMessage` to include a `-Filter` parameter to allow removal of messages matching a filter in a single command
   * Improved pipeline support for `Remove-GSGmailMessage`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 
 * [Issue #87](https://github.com/scrthq/PSGSuite/issues/87)
   * Fixed `Add-GSCourseParticipant` error: `"Cannot convert the "student@uni.edu" value of type "System.String" to type "Google.Apis.Classroom.v1.Data.Student"."`
+* Added: `Id` alias for `User` parameter on `Get-GSUser` for better pipeline support
 
 ## 2.15.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-# Changelog <!-- omit in toc -->
+# Changelog
 
+* [2.15.3](#2153)
 * [2.15.2](#2152)
 * [2.15.1](#2151)
 * [2.15.0](#2150)
@@ -47,6 +48,11 @@
     * [Gmail Delegation Management Removed](#gmail-delegation-management-removed)
     * [Functions Removed](#functions-removed)
     * [Functions Aliased](#functions-aliased)
+
+## 2.15.3
+
+* [Issue #87](https://github.com/scrthq/PSGSuite/issues/87)
+  * Fixed `Add-GSCourseParticipant` error: `"Cannot convert the "student@uni.edu" value of type "System.String" to type "Google.Apis.Classroom.v1.Data.Student"."`
 
 ## 2.15.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 
 * [Issue #87](https://github.com/scrthq/PSGSuite/issues/87)
   * Fixed `Add-GSCourseParticipant` error: `"Cannot convert the "student@uni.edu" value of type "System.String" to type "Google.Apis.Classroom.v1.Data.Student"."`
+  * Set `$request.Fields = "*"` for `Get-GSCourseParticipant` and `Get-GSClassroomUserProfile` to return all available fields for the `Profile`, including `EmailAddress`
 * Added: `Id` alias for `User` parameter on `Get-GSUser` for better pipeline support
 
 ## 2.15.2

--- a/PSGSuite/PSGSuite.psd1
+++ b/PSGSuite/PSGSuite.psd1
@@ -12,7 +12,7 @@
     RootModule            = 'PSGSuite.psm1'
 
     # Version number of this module.
-    ModuleVersion         = '2.15.2'
+    ModuleVersion         = '2.15.3'
 
     # ID used to uniquely identify this module
     GUID                  = '9d751152-e83e-40bb-a6db-4c329092aaec'

--- a/PSGSuite/Public/Classroom/Add-GSCourseParticipant.ps1
+++ b/PSGSuite/Public/Classroom/Add-GSCourseParticipant.ps1
@@ -78,7 +78,7 @@ function Add-GSCourseParticipant {
                 }
                 $body.UserId = $part
                 Write-Verbose "Adding Student '$part' to Course '$CourseId'"
-                $request = $service.Courses.Students.Create($part,$CourseId)
+                $request = $service.Courses.Students.Create($body,$CourseId)
                 $request.Execute()
             }
             catch {
@@ -106,7 +106,7 @@ function Add-GSCourseParticipant {
                 }
                 $body.UserId = $part
                 Write-Verbose "Adding Teacher '$part' to Course '$CourseId'"
-                $request = $service.Courses.Teachers.Create($part,$CourseId)
+                $request = $service.Courses.Teachers.Create($body,$CourseId)
                 $request.Execute()
             }
             catch {

--- a/PSGSuite/Public/Classroom/Get-GSClassroomUserProfile.ps1
+++ b/PSGSuite/Public/Classroom/Get-GSClassroomUserProfile.ps1
@@ -16,10 +16,11 @@ function Get-GSClassroomUserProfile {
     .EXAMPLE
     Get-GSClassroomUserProfile -UserId aristotle@athens.edu
     #>
-    [cmdletbinding(DefaultParameterSetName = "List")]
+    [cmdletbinding()]
     Param
     (
-        [parameter(Mandatory = $true,Position = 0)]
+        [parameter(Mandatory = $true,Position = 0,ValueFromPipelineByPropertyName = $true)]
+        [Alias('Id','PrimaryEmail','Mail','UserKey')]
         [ValidateNotNullOrEmpty()]
         [String[]]
         $UserId

--- a/PSGSuite/Public/Classroom/Get-GSClassroomUserProfile.ps1
+++ b/PSGSuite/Public/Classroom/Get-GSClassroomUserProfile.ps1
@@ -44,6 +44,7 @@ function Get-GSClassroomUserProfile {
                 }
                 Write-Verbose "Getting Classroom User Profile for '$part'"
                 $request = $service.UserProfiles.Get($part)
+                $request.Fields = "*"
                 $request.Execute()
             }
             catch {

--- a/PSGSuite/Public/Classroom/Get-GSCourseParticipant.ps1
+++ b/PSGSuite/Public/Classroom/Get-GSCourseParticipant.ps1
@@ -89,6 +89,7 @@ function Get-GSCourseParticipant {
                         }
                         Write-Verbose "Getting Student '$part' for Course '$CourseId'"
                         $request = $service.Courses.Students.Get($CourseId,$part)
+                        $request.Fields = "*"
                         $request.Execute()
                     }
                     catch {
@@ -115,6 +116,7 @@ function Get-GSCourseParticipant {
                         }
                         Write-Verbose "Getting Teacher '$part' for Course '$CourseId'"
                         $request = $service.Courses.Teachers.Get($CourseId,$part)
+                        $request.Fields = "*"
                         $request.Execute()
                     }
                     catch {
@@ -139,6 +141,7 @@ function Get-GSCourseParticipant {
                                 $service.Courses.Students.List($CourseId)
                             }
                         }
+                        $request.Fields = "*"
                         [int]$retrieved = 0
                         [int]$i = 1
                         do {

--- a/PSGSuite/Public/Users/Get-GSUser.ps1
+++ b/PSGSuite/Public/Users/Get-GSUser.ps1
@@ -98,7 +98,7 @@ function Get-GSUser {
     Param
     (
         [parameter(Mandatory = $false,Position = 0,ValueFromPipeline = $true,ValueFromPipelineByPropertyName = $true,ParameterSetName = "Get")]
-        [Alias("PrimaryEmail","UserKey","Mail","Email")]
+        [Alias("PrimaryEmail","UserKey","Mail","Email","Id")]
         [ValidateNotNullOrEmpty()]
         [String[]]
         $User = $Script:PSGSuite.AdminEmail,

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Update-GSSheetValue               Export-GSSheet
 
 * [Issue #87](https://github.com/scrthq/PSGSuite/issues/87)
   * Fixed `Add-GSCourseParticipant` error: `"Cannot convert the "student@uni.edu" value of type "System.String" to type "Google.Apis.Classroom.v1.Data.Student"."`
+* Added: `Id` alias for `User` parameter on `Get-GSUser` for better pipeline support
 
 #### 2.15.2
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Update-GSSheetValue               Export-GSSheet
 
 * [Issue #87](https://github.com/scrthq/PSGSuite/issues/87)
   * Fixed `Add-GSCourseParticipant` error: `"Cannot convert the "student@uni.edu" value of type "System.String" to type "Google.Apis.Classroom.v1.Data.Student"."`
+  * Set `$request.Fields = "*"` for `Get-GSCourseParticipant` and `Get-GSClassroomUserProfile` to return all available fields for the `Profile`, including `EmailAddress`
 * Added: `Id` alias for `User` parameter on `Get-GSUser` for better pipeline support
 
 #### 2.15.2

--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ Update-GSSheetValue               Export-GSSheet
 * [Issue #87](https://github.com/scrthq/PSGSuite/issues/87)
   * Fixed `Add-GSCourseParticipant` error: `"Cannot convert the "student@uni.edu" value of type "System.String" to type "Google.Apis.Classroom.v1.Data.Student"."`
   * Set `$request.Fields = "*"` for `Get-GSCourseParticipant` and `Get-GSClassroomUserProfile` to return all available fields for the `Profile`, including `EmailAddress`
+* [Issue #93](https://github.com/scrthq/PSGSuite/issues/93)
+  * Added: `MaxToModify` parameter to `Remove-GSGmailMessage` and `Update-GSGmailMessageLabels` in the `Filter` parameter set to prevent removing/updating more messages than expected when using a filter to gather the list of messages to update.
 * Added: `Id` alias for `User` parameter on `Get-GSUser` for better pipeline support
 
 #### 2.15.2

--- a/README.md
+++ b/README.md
@@ -127,6 +127,11 @@ Update-GSSheetValue               Export-GSSheet
 
 ### Most recent changes
 
+#### 2.15.3
+
+* [Issue #87](https://github.com/scrthq/PSGSuite/issues/87)
+  * Fixed `Add-GSCourseParticipant` error: `"Cannot convert the "student@uni.edu" value of type "System.String" to type "Google.Apis.Classroom.v1.Data.Student"."`
+
 #### 2.15.2
 
 * [Pull Request #94](https://github.com/scrthq/PSGSuite/pull/94) **Thanks, [@dwrusse](https://github.com/dwrusse)!**


### PR DESCRIPTION
## 2.15.3

* [Issue #87](https://github.com/scrthq/PSGSuite/issues/87)
  * Fixed `Add-GSCourseParticipant` error: `"Cannot convert the "student@uni.edu" value of type "System.String" to type "Google.Apis.Classroom.v1.Data.Student"."`
  * Set `$request.Fields = "*"` for `Get-GSCourseParticipant` and `Get-GSClassroomUserProfile` to return all available fields for the `Profile`, including `EmailAddress`
* [Issue #93](https://github.com/scrthq/PSGSuite/issues/93)
  * Added: `MaxToModify` parameter to `Remove-GSGmailMessage` and `Update-GSGmailMessageLabels` in the `Filter` parameter set to prevent removing/updating more messages than expected when using a filter to gather the list of messages to update.
* Added: `Id` alias for `User` parameter on `Get-GSUser` for better pipeline support