### PR TITLE
Added Remove-GSUserPhone function

### DIFF
--- a/PSGSuite/Public/Helpers/Remove-GSUserPhone.ps1
+++ b/PSGSuite/Public/Helpers/Remove-GSUserPhone.ps1
@@ -1,0 +1,50 @@
+function Remove-GSUserPhone {
+    <#
+    .SYNOPSIS
+    Remove User Phone
+    
+    .DESCRIPTION
+    Remove User Phone
+
+    .PARAMETER User
+    Email Address of User
+
+    .EXAMPLE
+    Remove-GSUserPhone -User <username> 
+
+    #>
+    [cmdletbinding(DefaultParameterSetName = "Update")]
+    Param
+    (
+        [parameter(Mandatory = $true)]
+        [string[]]
+        $User
+    )
+    Begin {
+     
+    }
+    Process {
+        try {
+            $header = @{
+                Authorization = "Bearer $(Get-GSToken -P12KeyPath $global:PSGSuite.P12KeyPath -Scopes "https://www.googleapis.com/auth/admin.directory.user" -AppEmail $global:PSGSuite.AppEmail -AdminEmail $global:PSGSuite.AdminEmail -Verbose:$false)"
+            }
+            $body = '{ "phones": null }'
+            $hook = "https://www.googleapis.com/admin/directory/v1/users/$User"
+            Write-Verbose "Removing Phone on User: $User"
+            Invoke-RestMethod -Method Put -Uri ([Uri]$hook) -Headers $header -Body $body -ContentType 'application/json' -Verbose:$false 
+        }
+        catch {
+            if ($ErrorActionPreference -eq 'Stop') {
+                $PSCmdlet.ThrowTerminatingError($_)
+            }
+            else {
+                Write-Error $_
+            }
+        }
+    
+    }
+    End {
+
+          
+    }
+}

--- a/PSGSuite/Public/Helpers/Remove-GSUserPhone.ps1
+++ b/PSGSuite/Public/Helpers/Remove-GSUserPhone.ps1
@@ -26,7 +26,7 @@ function Remove-GSUserPhone {
     Process {
         try {
             $header = @{
-                Authorization = "Bearer $(Get-GSToken -P12KeyPath $global:PSGSuite.P12KeyPath -Scopes "https://www.googleapis.com/auth/admin.directory.user" -AppEmail $global:PSGSuite.AppEmail -AdminEmail $global:PSGSuite.AdminEmail -Verbose:$false)"
+                Authorization = "Bearer $(Get-GSToken -P12KeyPath $script:PSGSuite.P12KeyPath -Scopes "https://www.googleapis.com/auth/admin.directory.user" -AppEmail $global:PSGSuite.AppEmail -AdminEmail $global:PSGSuite.AdminEmail -Verbose:$false)"
             }
             $body = '{ "phones": null }'
             $hook = "https://www.googleapis.com/admin/directory/v1/users/$User"


### PR DESCRIPTION
I found that the .NET library was sending 

`{ "phones": [] }`

instead of:

`{ "phones": null } `

which resulted in the phone object not being deleted. may have something to do with [this](https://stackoverflow.com/questions/19121076/google-admin-sdk-deleting-all-phone-numbers-for-a-user) issues

I wrote a function which sends the latter fragment of JSON to get the desired outcome. 
