### PR TITLE
pushing updates for v2.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 * [Changelog](#changelog)
+  * [2.21.0](#2210)
   * [2.20.2](#2202)
   * [2.20.1](#2201)
   * [2.20.0](#2200)
@@ -63,6 +64,15 @@
       * [Functions Aliased](#functions-aliased)
 
 ***
+
+## 2.21.0
+
+* [PR #130](https://github.com/scrthq/PSGSuite/pull/130) / [Issue #129](https://github.com/scrthq/PSGSuite/issues/129)
+  * Added: Support for UserRelations management in `New-GSUser -Relations $relations` and `Update-GSUser -Relations $relations` via `Add-GSUserRelation` helper function. - _Thanks, [@mattwoolnough](https://github.com/mattwoolnough)!_
+  * Added: Logic to `Update-GSUser` to enable clearing of all values for user properties `Phones`, `ExternalIds`, `Organizations`, and `Relations` by REST API call via passing `$null` as the value when calling `Update-GSUser`. - _Thanks, [@mattwoolnough](https://github.com/mattwoolnough)!_
+* [Issue #129](https://github.com/scrthq/PSGSuite/issues/129)
+  * Fixed: Documentation for `Get-GSSheetInfo` around the `Fields` parameter.
+  * Added: Additional correction of casing for `Fields` values in `Get-GSSheetInfo` so that it will always submit the values using the correct case, even if providing the incorrect case as the value to the parameter.
 
 ## 2.20.2
 

--- a/PSGSuite/PSGSuite.psd1
+++ b/PSGSuite/PSGSuite.psd1
@@ -12,7 +12,7 @@
     RootModule            = 'PSGSuite.psm1'
 
     # Version number of this module.
-    ModuleVersion         = '2.20.2'
+    ModuleVersion         = '2.21.0'
 
     # ID used to uniquely identify this module
     GUID                  = '9d751152-e83e-40bb-a6db-4c329092aaec'

--- a/PSGSuite/Public/Helpers/Add-GSUserRelation.ps1
+++ b/PSGSuite/Public/Helpers/Add-GSUserRelation.ps1
@@ -6,16 +6,34 @@ function Add-GSUserRelation {
     .DESCRIPTION
     Builds a Relation object to use when creating or updating a User
 
-    .PARAMETER CustomType
-    If the external ID type is custom, this property holds the custom type
-
     .PARAMETER Type
-    The type of the organization.
+    The type of relation.
 
-    If using a CustomType
+    Acceptable values are:
+    * "admin_assistant"
+    * "assistant"
+    * "brother"
+    * "child"
+    * "custom"
+    * "domestic_partner"
+    * "dotted_line_manager"
+    * "exec_assistant"
+    * "father"
+    * "friend"
+    * "manager"
+    * "mother"
+    * "parent"
+    * "partner"
+    * "referred_by"
+    * "relative"
+    * "sister"
+    * "spouse"
 
     .PARAMETER Value
-    The value of the ID
+    The name of the person the user is related to.
+
+    .PARAMETER CustomType
+    If the value of `Type` is `custom`, this property contains the custom type.
 
     .PARAMETER InputObject
     Used for pipeline input of an existing UserExternalId object to strip the extra attributes and prevent errors
@@ -37,14 +55,15 @@ function Add-GSUserRelation {
     Param
     (
         [Parameter(Mandatory = $false, ParameterSetName = "Fields")]
-        [String]
-        $CustomType,
-        [Parameter(Mandatory = $false, ParameterSetName = "Fields")]
+        [ValidateSet("admin_assistant","assistant","brother","child","custom","domestic_partner","dotted_line_manager","exec_assistant","father","friend","manager","mother","parent","partner","referred_by","relative","sister","spouse")]
         [String]
         $Type,
         [Parameter(Mandatory = $false, ParameterSetName = "Fields")]
         [String]
         $Value,
+        [Parameter(Mandatory = $false, ParameterSetName = "Fields")]
+        [String]
+        $CustomType,
         [Parameter(Mandatory = $false, ParameterSetName = "Fields")]
         [String]
         $ETag,
@@ -60,8 +79,9 @@ function Add-GSUserRelation {
             'ETag'
         )
         if ($PSBoundParameters.Keys -contains 'CustomType') {
-            $PSBoundParameters['Type'] = 'CUSTOM'
+            $PSBoundParameters['Type'] = 'custom'
         }
+        $PSBoundParameters['Type'] = $PSBoundParameters['Type'].ToString().ToLower()
     }
     Process {
         try {

--- a/PSGSuite/Public/Sheets/Get-GSSheetInfo.ps1
+++ b/PSGSuite/Public/Sheets/Get-GSSheetInfo.ps1
@@ -2,37 +2,37 @@ function Get-GSSheetInfo {
     <#
     .SYNOPSIS
     Gets metadata about a SpreadSheet
-    
+
     .DESCRIPTION
     Gets metadata about a SpreadSheet
-    
+
     .PARAMETER SpreadsheetId
     The unique Id of the SpreadSheet to retrieve info for
-    
+
     .PARAMETER User
     The owner of the SpreadSheet
-    
+
     .PARAMETER SheetName
     The name of the Sheet to retrieve info for
-    
+
     .PARAMETER Range
     The specific range of the Sheet to retrieve info for
-    
+
     .PARAMETER IncludeGridData
     Whether or not to include Grid Data in the response
-    
+
     .PARAMETER Fields
     The fields to return in the response
 
     Available values are:
-    * "NamedRanges"
-    * "Properties"
-    * "Sheets"
-    * "SpreadsheetId"
-    
+    * "namedRanges"
+    * "properties"
+    * "sheets"
+    * "spreadsheetId"
+
     .PARAMETER Raw
     If $true, return the raw response, otherwise, return a flattened response for readability
-    
+
     .EXAMPLE
     Get-GSSheetInfo -SpreadsheetId '1rhsAYTOB_vrpvfwImPmWy0TcVa2sgmQa_9u976'
 
@@ -40,7 +40,7 @@ function Get-GSSheetInfo {
     #>
     [cmdletbinding()]
     Param
-    (      
+    (
         [parameter(Mandatory = $true)]
         [String]
         $SpreadsheetId,
@@ -99,7 +99,7 @@ function Get-GSSheetInfo {
                 $request.Ranges = [Google.Apis.Util.Repeatable[String]]::new([String[]]$Range)
             }
             if ($Fields) {
-                $request.Fields = "$($Fields -join ",")"
+                $request.Fields = "$(($Fields | ForEach-Object {$f = $_;@("namedRanges","properties","sheets","spreadsheetId") | Where-Object {$_ -eq $f}}) -join ",")"
             }
             elseif ($PSBoundParameters.Keys -contains 'IncludeGridData') {
                 $request.IncludeGridData = $IncludeGridData

--- a/README.md
+++ b/README.md
@@ -131,9 +131,18 @@ Update-GSSheetValue               Export-GSSheet
 
 ### Most recent changes
 
+#### 2.21.0
+
+* [PR #130](https://github.com/scrthq/PSGSuite/pull/130) / [Issue #129](https://github.com/scrthq/PSGSuite/issues/129)
+  * Added: Support for UserRelations management in `New-GSUser -Relations $relations` and `Update-GSUser -Relations $relations` via `Add-GSUserRelation` helper function. - _Thanks, [@mattwoolnough](https://github.com/mattwoolnough)!_
+  * Added: Logic to `Update-GSUser` to enable clearing of all values for user properties `Phones`, `ExternalIds`, `Organizations`, and `Relations` by REST API call via passing `$null` as the value when calling `Update-GSUser`. - _Thanks, [@mattwoolnough](https://github.com/mattwoolnough)!_
+* [Issue #129](https://github.com/scrthq/PSGSuite/issues/129)
+  * Fixed: Documentation for `Get-GSSheetInfo` around the `Fields` parameter.
+  * Added: Additional correction of casing for `Fields` values in `Get-GSSheetInfo` so that it will always submit the values using the correct case, even if providing the incorrect case as the value to the parameter.
+
 #### 2.20.2
 
-* [Issue #120](https://github.com/scrthq/PSGSuite/issues/120)
+* [Issue #128](https://github.com/scrthq/PSGSuite/issues/128)
   * Added: `Update-GSMobileDevice` to allow taking action on Mobile Devices
   * Fixed: Bug in `Remove-GSMobileDevice` with incorrect variable name
 


### PR DESCRIPTION
## 2.21.0

* [PR #130](https://github.com/scrthq/PSGSuite/pull/130) / [Issue #129](https://github.com/scrthq/PSGSuite/issues/129)
  * Added: Support for UserRelations management in `New-GSUser -Relations $relations` and `Update-GSUser -Relations $relations` via `Add-GSUserRelation` helper function. - _Thanks, [@mattwoolnough](https://github.com/mattwoolnough)!_
  * Added: Logic to `Update-GSUser` to enable clearing of all values for user properties `Phones`, `ExternalIds`, `Organizations`, and `Relations` by REST API call via passing `$null` as the value when calling `Update-GSUser`. - _Thanks, [@mattwoolnough](https://github.com/mattwoolnough)!_
* [Issue #129](https://github.com/scrthq/PSGSuite/issues/129)
  * Fixed: Documentation for `Get-GSSheetInfo` around the `Fields` parameter.
  * Added: Additional correction of casing for `Fields` values in `Get-GSSheetInfo` so that it will always submit the values using the correct case, even if providing the incorrect case as the value to the parameter.