### PR TITLE
v2.21.2 - fix for #136

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 * [Changelog](#changelog)
+  * [2.21.2](#2212)
   * [2.21.1](#2211)
   * [2.21.0](#2210)
   * [2.20.2](#2202)
@@ -65,6 +66,11 @@
       * [Functions Aliased](#functions-aliased)
 
 ***
+
+## 2.21.2
+
+* [Issue #136](https://github.com/scrthq/PSGSuite/issues/136)
+  * Fixed: `Start-GSDriveFileUpload` failing when specifying a user other than the Admin user to do the upload as.
 
 ## 2.21.1
 

--- a/PSGSuite/PSGSuite.psd1
+++ b/PSGSuite/PSGSuite.psd1
@@ -12,7 +12,7 @@
     RootModule            = 'PSGSuite.psm1'
 
     # Version number of this module.
-    ModuleVersion         = '2.21.1'
+    ModuleVersion         = '2.21.2'
 
     # ID used to uniquely identify this module
     GUID                  = '9d751152-e83e-40bb-a6db-4c329092aaec'

--- a/PSGSuite/Public/Drive/Start-GSDriveFileUpload.ps1
+++ b/PSGSuite/Public/Drive/Start-GSDriveFileUpload.ps1
@@ -2,43 +2,43 @@ function Start-GSDriveFileUpload {
     <#
     .SYNOPSIS
     Starts uploading a file or list of files to Drive asynchronously
-    
+
     .DESCRIPTION
     Starts uploading a file or list of files to Drive asynchronously. Allows full folder structure uploads by passing a folder as -Path and including the -Recurse parameter
-    
+
     .PARAMETER Path
     The path of the file or folder to upload
-    
+
     .PARAMETER Name
     The new name of the file once uploaded
 
     Defaults to the existing name of the file or folder
-    
+
     .PARAMETER Description
     The description of the file or folder in Drive
-    
+
     .PARAMETER Parents
     The unique Id of the parent folder in Drive to upload the file to
 
     Defaults to the root folder in My Drive
-    
+
     .PARAMETER Recurse
     If $true and there is a Directory passed to -Path, this will rebuild the folder structure in Drive under the Parent Id and upload the files within accordingly
-    
+
     .PARAMETER Wait
     If $true, waits for all uploads to complete and shows progress around the total upload
-    
+
     .PARAMETER RetryCount
     How many times uploads should be retried when using the -Wait parameter
 
     Defaults to 10
-    
+
     .PARAMETER ThrottleLimit
     The limit of files to upload per batch while waiting
-    
+
     .PARAMETER User
     The email or unique Id of the user to upload the files for
-    
+
     .EXAMPLE
     Start-GSDriveFileUpload -Path "C:\Scripts","C:\Modules" -Recurse -Wait
 
@@ -107,6 +107,7 @@ function Start-GSDriveFileUpload {
                 if ($details.PSIsContainer) {
                     $newFolPerms = @{
                         Name    = $details.Name
+                        User    = $User
                         Type    = 'DriveFolder'
                         Verbose = $false
                     }
@@ -125,6 +126,7 @@ function Start-GSDriveFileUpload {
                                 $parPath = "$(Split-Path $_.FullName -Parent)"
                                 $newFolPerms = @{
                                     Name    = $_.Name
+                                    User    = $User
                                     Type    = 'DriveFolder'
                                     Parents = [String[]]$folIdHash[$parPath]
                                     Verbose = $false

--- a/README.md
+++ b/README.md
@@ -136,6 +136,11 @@ Update-GSSheetValue               Export-GSSheet
 
 ### Most recent changes
 
+#### 2.21.2
+
+* [Issue #136](https://github.com/scrthq/PSGSuite/issues/136)
+  * Fixed: `Start-GSDriveFileUpload` failing when specifying a user other than the Admin user to do the upload as.
+
 #### 2.21.1
 
 * [Issue #131](https://github.com/scrthq/PSGSuite/issues/131) - _Free/standard Google Account support_


### PR DESCRIPTION
## 2.21.2

* [Issue #136](https://github.com/scrthq/PSGSuite/issues/136)
  * Fixed: `Start-GSDriveFileUpload` failing when specifying a user other than the Admin user to do the upload as.