### PR TITLE
v2.21.3 - fix for client_secrets.json auth on PowerShell Core to Prompt instead, added OutputType to all relevant functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 * [Changelog](#changelog)
+  * [2.21.3](#2213)
   * [2.21.2](#2212)
   * [2.21.1](#2211)
   * [2.21.0](#2210)
@@ -66,6 +67,13 @@
       * [Functions Aliased](#functions-aliased)
 
 ***
+
+## 2.21.3
+
+* [Issue #131](https://github.com/scrthq/PSGSuite/issues/131)
+  * Fixed: Changed `CodeReceiver` to use `PromptCodeReceiver` when client is PowerShell Core, as `LocalServerCodeReceiver` does not appear to redirect correctly and auth fails. Same behavior in Core regardless of OS.
+* Miscellaneous
+  * Added: `OutputType` to all functions that return standard objects.
 
 ## 2.21.2
 

--- a/PSGSuite/PSGSuite.psd1
+++ b/PSGSuite/PSGSuite.psd1
@@ -12,7 +12,7 @@
     RootModule            = 'PSGSuite.psm1'
 
     # Version number of this module.
-    ModuleVersion         = '2.21.2'
+    ModuleVersion         = '2.21.3'
 
     # ID used to uniquely identify this module
     GUID                  = '9d751152-e83e-40bb-a6db-4c329092aaec'

--- a/PSGSuite/Public/Authentication/Get-GSToken.ps1
+++ b/PSGSuite/Public/Authentication/Get-GSToken.ps1
@@ -24,68 +24,20 @@ function Get-GSToken {
         [Alias('User')]
         [ValidateNotNullOrEmpty()]
         [String]
-        $AdminEmail = $Script:PSGSuite.AdminEmail,
-        [parameter(Mandatory = $false)]
-        [Switch]
-        $UseRest
+        $AdminEmail = $Script:PSGSuite.AdminEmail
     )
-    if ($UseRest) {
-        function Invoke-URLEncode ($Object) {
-            ([String]([System.Convert]::ToBase64String($Object))).TrimEnd('=').Replace('+','-').Replace('/','_')
+    try {
+        Write-Verbose "Acquiring access token"
+        $serviceParams = @{
+            Scope       = $Scopes
+            ServiceType = 'Google.Apis.Gmail.v1.GmailService'
+            User        = $AdminEmail
         }
-        $googleCert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2("$($Script:PSGSuite.P12KeyPath)", "notasecret",[System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::Exportable )
-        $rsaPrivate = $googleCert.PrivateKey
-        $rsa = New-Object System.Security.Cryptography.RSACryptoServiceProvider
-        $rsa.ImportParameters($rsaPrivate.ExportParameters($true))
-        $rawheader = [Ordered]@{
-            alg = "RS256"
-            typ = "JWT"
-        } | ConvertTo-Json -Compress
-        $header = Invoke-URLEncode ([System.Text.Encoding]::UTF8.GetBytes($rawheader))
-        [string]$now = Get-Date (Get-Date).ToUniversalTime() -UFormat "%s"
-        [int]$createDate = $now -replace "(\..*|\,.*)"
-        [int]$expiryDate = $createDate + 3600
-        $rawclaims = [Ordered]@{
-            iss   = "$($Script:PSGSuite.AppEmail)"
-            sub   = "$($Script:PSGSuite.AdminEmail)"
-            scope = "$($Scopes -join " ")"
-            aud   = "https://www.googleapis.com/oauth2/v4/token"
-            exp   = "$expiryDate"
-            iat   = "$createDate"
-        } | ConvertTo-Json
-        $claims = Invoke-URLEncode ([System.Text.Encoding]::UTF8.GetBytes($rawclaims))
-        $toSign = [System.Text.Encoding]::UTF8.GetBytes($header + "." + $claims)
-        $sig = Invoke-URLEncode ($rsa.SignData($toSign,"SHA256"))
-        $jwt = $header + "." + $claims + "." + $sig
-        $fields = [Ordered]@{
-            grant_type = 'urn:ietf:params:oauth:grant-type:jwt-bearer'
-            assertion  = $jwt
-        }
-        try {
-            Write-Verbose "Acquiring access token via REST API..."
-            $response = Invoke-RestMethod -Uri "https://www.googleapis.com/oauth2/v4/token" -Method Post -Body $fields -ContentType "application/x-www-form-urlencoded" -ErrorAction Stop -Verbose:$false
-            Write-Verbose "Access token acquired!"
-            return $response
-        }
-        catch {
-            Write-Verbose "Failed to acquire access token!"
-            $PSCmdlet.ThrowTerminatingError($_)
-        }
+        $service = New-GoogleService @serviceParams
+        ($service.HttpClientInitializer.GetAccessTokenForRequestAsync()).Result
     }
-    else {
-        try {
-            Write-Verbose "Acquiring access token via .NET SDK..."
-            $serviceParams = @{
-                Scope       = $Scopes
-                ServiceType = 'Google.Apis.Gmail.v1.GmailService'
-                User        = $AdminEmail
-            }
-            $service = New-GoogleService @serviceParams
-            ($service.HttpClientInitializer.GetAccessTokenForRequestAsync()).Result
-        }
-        catch {
-            Write-Verbose "Failed to acquire access token!"
-            $PSCmdlet.ThrowTerminatingError($_)
-        }
+    catch {
+        Write-Verbose "Failed to acquire access token!"
+        $PSCmdlet.ThrowTerminatingError($_)
     }
 }

--- a/PSGSuite/Public/Authentication/Get-GSToken.ps1
+++ b/PSGSuite/Public/Authentication/Get-GSToken.ps1
@@ -24,20 +24,68 @@ function Get-GSToken {
         [Alias('User')]
         [ValidateNotNullOrEmpty()]
         [String]
-        $AdminEmail = $Script:PSGSuite.AdminEmail
+        $AdminEmail = $Script:PSGSuite.AdminEmail,
+        [parameter(Mandatory = $false)]
+        [Switch]
+        $UseRest
     )
-    try {
-        Write-Verbose "Acquiring access token..."
-        $serviceParams = @{
-            Scope       = $Scopes
-            ServiceType = 'Google.Apis.Gmail.v1.GmailService'
-            User        = $AdminEmail
+    if ($UseRest) {
+        function Invoke-URLEncode ($Object) {
+            ([String]([System.Convert]::ToBase64String($Object))).TrimEnd('=').Replace('+','-').Replace('/','_')
         }
-        $service = New-GoogleService @serviceParams
-        ($service.HttpClientInitializer.GetAccessTokenForRequestAsync()).Result
+        $googleCert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2("$($Script:PSGSuite.P12KeyPath)", "notasecret",[System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::Exportable )
+        $rsaPrivate = $googleCert.PrivateKey
+        $rsa = New-Object System.Security.Cryptography.RSACryptoServiceProvider
+        $rsa.ImportParameters($rsaPrivate.ExportParameters($true))
+        $rawheader = [Ordered]@{
+            alg = "RS256"
+            typ = "JWT"
+        } | ConvertTo-Json -Compress
+        $header = Invoke-URLEncode ([System.Text.Encoding]::UTF8.GetBytes($rawheader))
+        [string]$now = Get-Date (Get-Date).ToUniversalTime() -UFormat "%s"
+        [int]$createDate = $now -replace "(\..*|\,.*)"
+        [int]$expiryDate = $createDate + 3600
+        $rawclaims = [Ordered]@{
+            iss   = "$($Script:PSGSuite.AppEmail)"
+            sub   = "$($Script:PSGSuite.AdminEmail)"
+            scope = "$($Scopes -join " ")"
+            aud   = "https://www.googleapis.com/oauth2/v4/token"
+            exp   = "$expiryDate"
+            iat   = "$createDate"
+        } | ConvertTo-Json
+        $claims = Invoke-URLEncode ([System.Text.Encoding]::UTF8.GetBytes($rawclaims))
+        $toSign = [System.Text.Encoding]::UTF8.GetBytes($header + "." + $claims)
+        $sig = Invoke-URLEncode ($rsa.SignData($toSign,"SHA256"))
+        $jwt = $header + "." + $claims + "." + $sig
+        $fields = [Ordered]@{
+            grant_type = 'urn:ietf:params:oauth:grant-type:jwt-bearer'
+            assertion  = $jwt
+        }
+        try {
+            Write-Verbose "Acquiring access token via REST API..."
+            $response = Invoke-RestMethod -Uri "https://www.googleapis.com/oauth2/v4/token" -Method Post -Body $fields -ContentType "application/x-www-form-urlencoded" -ErrorAction Stop -Verbose:$false
+            Write-Verbose "Access token acquired!"
+            return $response
+        }
+        catch {
+            Write-Verbose "Failed to acquire access token!"
+            $PSCmdlet.ThrowTerminatingError($_)
+        }
     }
-    catch {
-        Write-Verbose "Failed to acquire access token!"
-        $PSCmdlet.ThrowTerminatingError($_)
+    else {
+        try {
+            Write-Verbose "Acquiring access token via .NET SDK..."
+            $serviceParams = @{
+                Scope       = $Scopes
+                ServiceType = 'Google.Apis.Gmail.v1.GmailService'
+                User        = $AdminEmail
+            }
+            $service = New-GoogleService @serviceParams
+            ($service.HttpClientInitializer.GetAccessTokenForRequestAsync()).Result
+        }
+        catch {
+            Write-Verbose "Failed to acquire access token!"
+            $PSCmdlet.ThrowTerminatingError($_)
+        }
     }
 }

--- a/PSGSuite/Public/Authentication/New-GoogleService.ps1
+++ b/PSGSuite/Public/Authentication/New-GoogleService.ps1
@@ -14,17 +14,22 @@ function New-GoogleService {
         $User = $script:PSGSuite.AdminEmail
     )
     Process {
-        try {
-            if ($script:PSGSuite.P12KeyPath) {
+        if ($script:PSGSuite.P12KeyPath) {
+            try {
                 Write-Verbose "Building ServiceAccountCredential from P12Key as user '$User'"
                 $certificate = New-Object 'System.Security.Cryptography.X509Certificates.X509Certificate2' -ArgumentList (Resolve-Path $script:PSGSuite.P12KeyPath),"notasecret",([System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::Exportable)
                 $credential = New-Object 'Google.Apis.Auth.OAuth2.ServiceAccountCredential' (New-Object 'Google.Apis.Auth.OAuth2.ServiceAccountCredential+Initializer' $script:PSGSuite.AppEmail -Property @{
-                        User   = $User
-                        Scopes = [string[]]$Scope
-                    }
+                    User   = $User
+                    Scopes = [string[]]$Scope
+                }
                 ).FromCertificate($certificate)
             }
-            elseif ($script:PSGSuite.ClientSecretsPath -or $script:PSGSuite.ClientSecrets) {
+            catch {
+                $PSCmdlet.ThrowTerminatingError($_)
+            }
+        }
+        elseif ($script:PSGSuite.ClientSecretsPath -or $script:PSGSuite.ClientSecrets) {
+            try {
                 $ClientSecretsScopes = @(
                     'https://www.google.com/m8/feeds'
                     'https://mail.google.com'
@@ -35,33 +40,38 @@ function New-GoogleService {
                     'https://www.googleapis.com/auth/tasks'
                     'https://www.googleapis.com/auth/tasks.readonly'
                 )
-                if (!$script:PSGSuite.ClientSecrets) {
+                if (-not $script:PSGSuite.ClientSecrets) {
                     $script:PSGSuite.ClientSecrets = (Get-Content $script:PSGSuite.ClientSecretsPath -Raw)
                     Set-PSGSuiteConfig -ConfigName $script:PSGSuite.ConfigName -ClientSecretsPath $script:PSGSuite.ClientSecretsPath -Verbose:$false
                 }
-                Write-Verbose "Building UserCredentials from ClientSecrets as user '$User'"
-                $stream = New-Object System.IO.MemoryStream $([System.Text.Encoding]::ASCII.GetBytes(($script:PSGSuite.ClientSecrets))),$null
                 $credPath = Join-Path (Resolve-Path (Join-Path "~" ".scrthq")) "PSGSuite"
+                Write-Verbose "Building UserCredentials from ClientSecrets as user '$User' and prompting for authorization if necessary."
+                $stream = New-Object System.IO.MemoryStream $([System.Text.Encoding]::ASCII.GetBytes(($script:PSGSuite.ClientSecrets))),$null
                 $credential = [Google.Apis.Auth.OAuth2.GoogleWebAuthorizationBroker]::AuthorizeAsync(
                     [Google.Apis.Auth.OAuth2.GoogleClientSecrets]::Load($stream).Secrets,
                     [string[]]$ClientSecretsScopes,
                     $User,
                     [System.Threading.CancellationToken]::None,
-                    [Google.Apis.Util.Store.FileDataStore]::new($credPath,$true)
+                    [Google.Apis.Util.Store.FileDataStore]::new($credPath,$true),
+                    $(if($PSVersionTable.PSVersion.Major -gt 5){New-Object 'Google.Apis.Auth.OAuth2.PromptCodeReceiver'}else{New-Object 'Google.Apis.Auth.OAuth2.LocalServerCodeReceiver'})
                 ).Result
-                $stream.Close()
             }
-            else {
-                $PSCmdlet.ThrowTerminatingError((ThrowTerm "The current config '$($script:PSGSuite.ConfigName)' does not contain a P12KeyPath or a ClientSecretsPath! PSGSuite is unable to build a credential object for the service without a path to a credential file! Please update the configuration to include a path at least one of the two credential types."))
+            catch {
+                $PSCmdlet.ThrowTerminatingError($_)
             }
-            New-Object "$ServiceType" (New-Object 'Google.Apis.Services.BaseClientService+Initializer' -Property @{
-                    HttpClientInitializer = $credential
-                    ApplicationName       = "PSGSuite - $env:USERNAME"
+            finally {
+                if ($stream) {
+                    $stream.Close()
                 }
-            )
+            }
         }
-        catch {
-            $PSCmdlet.ThrowTerminatingError($_)
+        else {
+            $PSCmdlet.ThrowTerminatingError((ThrowTerm "The current config '$($script:PSGSuite.ConfigName)' does not contain a P12KeyPath or a ClientSecretsPath! PSGSuite is unable to build a credential object for the service without a path to a credential file! Please update the configuration to include a path at least one of the two credential types."))
         }
+        New-Object "$ServiceType" (New-Object 'Google.Apis.Services.BaseClientService+Initializer' -Property @{
+                HttpClientInitializer = $credential
+                ApplicationName       = "PSGSuite - $env:USERNAME"
+            }
+        )
     }
 }

--- a/PSGSuite/Public/Calendar/Add-GSCalendarSubscription.ps1
+++ b/PSGSuite/Public/Calendar/Add-GSCalendarSubscription.ps1
@@ -2,63 +2,64 @@ function Add-GSCalendarSubscription {
     <#
     .SYNOPSIS
     Adds a calendar to a users calendar list (aka subscribes to the specified calendar)
-    
+
     .DESCRIPTION
     Adds a calendar to a users calendar list (aka subscribes to the specified calendar)
-    
+
     .PARAMETER User
     The primary email or UserID of the user. You can exclude the '@domain.com' to insert the Domain in the config or use the special 'me' to indicate the AdminEmail in the config.
-    
+
     .PARAMETER CalendarID
     The calendar ID of the calendar you would like to subscribe the user to
-    
+
     .PARAMETER Selected
     Whether the calendar content shows up in the calendar UI. Optional. The default is False.
-    
+
     .PARAMETER Hidden
     Whether the calendar has been hidden from the list. Optional. The default is False.
-    
+
     .PARAMETER DefaultReminderMethod
     The method used by this reminder. Defaults to email.
-    
+
     Possible values are:
     * "email" - Reminders are sent via email.
     * "sms" - Reminders are sent via SMS. These are only available for G Suite customers. Requests to set SMS reminders for other account types are ignored.
     * "popup" - Reminders are sent via a UI popup.
-    
+
     .PARAMETER DefaultReminderMinutes
     Number of minutes before the start of the event when the reminder should trigger. Defaults to 30 minutes.
-    
+
     Valid values are between 0 and 40320 (4 weeks in minutes).
-    
+
     .PARAMETER DefaultNotificationMethod
     The method used to deliver the notification. Defaults to email.
-    
+
     Possible values are:
     * "email" - Reminders are sent via email.
     * "sms" - Reminders are sent via SMS. This value is read-only and is ignored on inserts and updates. SMS reminders are only available for G Suite customers.
-    
+
     .PARAMETER DefaultNotificationType
     The type of notification. Defaults to eventChange.
-    
+
     Possible values are:
     * "eventCreation" - Notification sent when a new event is put on the calendar.
     * "eventChange" - Notification sent when an event is changed.
     * "eventCancellation" - Notification sent when an event is cancelled.
     * "eventResponse" - Notification sent when an event is changed.
     * "agenda" - An agenda with the events of the day (sent out in the morning).
-    
+
     .PARAMETER Color
     The color of the calendar.
-    
+
     .PARAMETER SummaryOverride
     The summary that the authenticated user has set for this calendar.
-    
+
     .EXAMPLE
     Add-GSCalendarSubscription -User me -CalendarId john.smith@domain.com -Selected -Color Cyan
 
     Adds the calendar 'john.smith@domain.com' to the AdminEmail user's calendar list
     #>
+    [OutputType('Google.Apis.Calendar.v3.Data.CalendarListEntry')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Calendar/Get-GSCalendarACL.ps1
+++ b/PSGSuite/Public/Calendar/Get-GSCalendarACL.ps1
@@ -2,15 +2,15 @@ function Get-GSCalendarACL {
     <#
     .SYNOPSIS
     Gets the ACL calendar for a calendar
-    
+
     .DESCRIPTION
-    Gets the ACL for a calendar 
-    
+    Gets the ACL for a calendar
+
     .PARAMETER User
     The primary email or UserID of the user. You can exclude the '@domain.com' to insert the Domain in the config or use the special 'me' to indicate the AdminEmail in the config.
 
     Defaults to the AdminEmail in the config
-    
+
     .PARAMETER CalendarId
     The calendar ID of the calendar you would like to list ACLS for.
 
@@ -18,15 +18,16 @@ function Get-GSCalendarACL {
 
     .PARAMETER RuleId
     The Id of the Rule you would like to retrieve specifically. Leave empty to return the full ACL list instead.
-    
+
     .PARAMETER PageSize
     Maximum number of events returned on one result page.
-    
+
     .EXAMPLE
     Get-GSCalendarACL -User me -CalendarID "primary"
-    
+
     This gets the ACL on the primary calendar of the AdminUser.
     #>
+    [OutputType('Google.Apis.Calendar.v3.Data.AclRule')]
     [cmdletbinding(DefaultParameterSetName = 'List')]
     Param
     (

--- a/PSGSuite/Public/Calendar/Get-GSCalendarEvent.ps1
+++ b/PSGSuite/Public/Calendar/Get-GSCalendarEvent.ps1
@@ -52,6 +52,7 @@ function Get-GSCalendarEvent {
 
     This gets the single events on the primary calendar of the Admin for the week of Jan 21-28, 2018.
     #>
+    [OutputType('Google.Apis.Calendar.v3.Data.Event')]
     [cmdletbinding(DefaultParameterSetName = "List")]
     Param
     (

--- a/PSGSuite/Public/Calendar/Get-GSCalendarSubscription.ps1
+++ b/PSGSuite/Public/Calendar/Get-GSCalendarSubscription.ps1
@@ -2,23 +2,24 @@ function Get-GSCalendarSubscription {
     <#
     .SYNOPSIS
     Gets a subscribed calendar from a users calendar list. Returns the full calendar list if no CalendarId is specified.
-    
+
     .DESCRIPTION
     Gets a subscribed calendar from a users calendar list. Returns the full calendar list if no CalendarId is specified.
-    
+
     .PARAMETER User
     The primary email or UserID of the user. You can exclude the '@domain.com' to insert the Domain in the config or use the special 'me' to indicate the AdminEmail in the config.
 
     Defaults to the AdminEmail in the config
-    
+
     .PARAMETER CalendarID
     The calendar ID of the calendar you would like to get info for. If left blank, returns the list of calendars the user is subscribed to.
-    
+
     .EXAMPLE
     Get-GSCalendarSubscription
 
     Gets the AdminEmail user's calendar list
     #>
+    [OutputType('Google.Apis.Calendar.v3.Data.CalendarListEntry')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Calendar/New-GSCalendarACL.ps1
+++ b/PSGSuite/Public/Calendar/New-GSCalendarACL.ps1
@@ -45,6 +45,7 @@ function New-GSCalendarACL {
 
     Gives Jonnyappleseed@domain.com reader access to jennyappleseed's calendar.
     #>
+    [OutputType('Google.Apis.Calendar.v3.Data.AclRule')]
     [cmdletbinding(DefaultParameterSetName = "AttendeeEmails")]
     Param
     (

--- a/PSGSuite/Public/Calendar/New-GSCalendarEvent.ps1
+++ b/PSGSuite/Public/Calendar/New-GSCalendarEvent.ps1
@@ -88,6 +88,7 @@ function New-GSCalendarEvent {
 
     Creates an event titled "Go to the gym" for 9-10PM the day the function is ran.
     #>
+    [OutputType('Google.Apis.Calendar.v3.Data.Event')]
     [cmdletbinding(DefaultParameterSetName = "AttendeeEmails")]
     Param
     (

--- a/PSGSuite/Public/Calendar/Update-GSCalendarEvent.ps1
+++ b/PSGSuite/Public/Calendar/Update-GSCalendarEvent.ps1
@@ -80,6 +80,7 @@ function Update-GSCalendarEvent {
 
     Creates an event titled "Go to the gym" for 9-10PM the day the function is ran.
     #>
+    [OutputType('Google.Apis.Calendar.v3.Data.Event')]
     [cmdletbinding(DefaultParameterSetName = "AttendeeEmails")]
     Param
     (

--- a/PSGSuite/Public/Chat/Get-GSChatMember.ps1
+++ b/PSGSuite/Public/Chat/Get-GSChatMember.ps1
@@ -2,7 +2,7 @@ function Get-GSChatMember {
     <#
     .SYNOPSIS
     Gets Chat member information
-    
+
     .DESCRIPTION
     Gets Chat member information
 
@@ -10,17 +10,18 @@ function Get-GSChatMember {
     Resource name of the membership to be retrieved, in the form "spaces/members".
 
     Example: spaces/AAAAMpdlehY/members/105115627578887013105
-    
+
     .PARAMETER Space
     The resource name of the space for which membership list is to be fetched, in the form "spaces".
 
     Example: spaces/AAAAMpdlehY
-    
+
     .EXAMPLE
     Get-GSChatMember -Space 'spaces/AAAAMpdlehY'
 
     Gets the list of human members in the Chat space specified
     #>
+    [OutputType('Google.Apis.HangoutsChat.v1.Data.Membership')]
     [cmdletbinding(DefaultParameterSetName = "List")]
     Param
     (
@@ -60,7 +61,7 @@ function Get-GSChatMember {
             }
             List {
                 foreach ($sp in $Space) {
-                    try {   
+                    try {
                         if ($sp -notlike "spaces/*") {
                             try {
                                 $sp = Get-GSChatConfig -SpaceName $sp -ErrorAction Stop

--- a/PSGSuite/Public/Chat/Get-GSChatMessage.ps1
+++ b/PSGSuite/Public/Chat/Get-GSChatMessage.ps1
@@ -2,7 +2,7 @@ function Get-GSChatMessage {
     <#
     .SYNOPSIS
     Gets a Chat message
-    
+
     .DESCRIPTION
     Gets a Chat message
 
@@ -10,12 +10,13 @@ function Get-GSChatMessage {
     Resource name of the message to be retrieved, in the form "spaces/messages".
 
     Example: spaces/AAAAMpdlehY/messages/UMxbHmzDlr4.UMxbHmzDlr4
-    
+
     .EXAMPLE
     Get-GSChatMessage -Name 'spaces/AAAAMpdlehY/messages/UMxbHmzDlr4.UMxbHmzDlr4'
 
     Gets the Chat message specified
     #>
+    [OutputType('Google.Apis.HangoutsChat.v1.Data.Message')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Chat/Get-GSChatSpace.ps1
+++ b/PSGSuite/Public/Chat/Get-GSChatSpace.ps1
@@ -2,22 +2,23 @@ function Get-GSChatSpace {
     <#
     .SYNOPSIS
     Gets a Chat space
-    
+
     .DESCRIPTION
     Gets a Chat space
-    
+
     .PARAMETER Space
     The resource name of the space for which membership list is to be fetched, in the form "spaces".
 
     If left blank, returns the list of spaces the bot is a member of
 
     Example: spaces/AAAAMpdlehY
-    
+
     .EXAMPLE
     Get-GSChatSpace
 
     Gets the list of Chat spaces the bot is a member of
     #>
+    [OutputType('Google.Apis.HangoutsChat.v1.Data.Space')]
     [cmdletbinding()]
     Param
     (
@@ -94,7 +95,7 @@ function Get-GSChatSpace {
         $spaceArray | ForEach-Object {
             if ($_.DisplayName) {
                 $spaceHashArray += @{$_.DisplayName = $_.Name}
-                
+
             }
             else {
                 $member = Get-GSChatMember -Space $_.Name -Verbose:$false

--- a/PSGSuite/Public/Chat/Send-GSChatMessage.ps1
+++ b/PSGSuite/Public/Chat/Send-GSChatMessage.ps1
@@ -2,7 +2,7 @@ function Send-GSChatMessage {
     <#
     .SYNOPSIS
     Sends a Chat message
-    
+
     .DESCRIPTION
     Sends a Chat message
 
@@ -34,7 +34,7 @@ function Send-GSChatMessage {
     Part of the ActionResponse. Parameters that a bot can use to configure how its response is posted.
 
     The ActionResponseUrl is the URL for users to auth or config. (Only for REQUEST_CONFIG response types.)
-    
+
     .PARAMETER Parent
     The resource name of the space to send the message to, in the form "spaces".
 
@@ -48,7 +48,7 @@ function Send-GSChatMessage {
 
     You can safely store an encrypted dictionary of Webhooks in the PSGSuite Config by passing a hashtable to the `-Webhook` parameter, i.e.:
         Set-PSGSuiteConfig -Webhook @{JobReports = 'https://chat.googleapis.com/v1/spaces/xxxxxxxxxx/messages?key=xxxxxxxxxxxxxxxxxx&token=xxxxxxxxxxxxxxxxxx'}
-    
+
     To retrieve a stored Webhook, you can use `Get-GSChatWebhook`, i.e.:
         Send-GSChatMessage -Text "Post job report:" -Cards $cards -Webhook (Get-GSChatWebhook JobReports)
 
@@ -67,13 +67,13 @@ function Send-GSChatMessage {
     Add-GSChatKeyValue -TopLabel "Chocolate Budget" -Content '$5.00' -Icon DOLLAR |
     Add-GSChatKeyValue -TopLabel "Actual Spending" -Content '$5,000,000!' -BottomLabel "WTF" -Icon AIRPLANE |
     Add-GSChatImage -ImageUrl "https://media.tenor.com/images/f78545a9b520ecf953578b4be220f26d/tenor.gif" -LinkImage |
-    Add-GSChatCardSection -SectionHeader "Dollar bills, y'all" -OutVariable sect1 | 
-    Add-GSChatButton -Text "Launch nuke" -OnClick (Add-GSChatOnClick -Url "https://github.com/scrthq/PSGSuite") -Verbose -OutVariable button1 | 
-    Add-GSChatButton -Text "Unleash hounds" -OnClick (Add-GSChatOnClick -Url "https://admin.google.com/?hl=en&authuser=0") -Verbose -OutVariable button2 | 
-    Add-GSChatCardSection -SectionHeader "What should we do?" -OutVariable sect2 | 
+    Add-GSChatCardSection -SectionHeader "Dollar bills, y'all" -OutVariable sect1 |
+    Add-GSChatButton -Text "Launch nuke" -OnClick (Add-GSChatOnClick -Url "https://github.com/scrthq/PSGSuite") -Verbose -OutVariable button1 |
+    Add-GSChatButton -Text "Unleash hounds" -OnClick (Add-GSChatOnClick -Url "https://admin.google.com/?hl=en&authuser=0") -Verbose -OutVariable button2 |
+    Add-GSChatCardSection -SectionHeader "What should we do?" -OutVariable sect2 |
     Add-GSChatCard -HeaderTitle "Makin' moves with" -HeaderSubtitle "DEM GOODIES" -OutVariable card |
-    Add-GSChatTextParagraph -Text "This message sent by <b>PSGSuite</b> via WebHook!" | 
-    Add-GSChatCardSection -SectionHeader "Additional Info" -OutVariable sect2 | 
+    Add-GSChatTextParagraph -Text "This message sent by <b>PSGSuite</b> via WebHook!" |
+    Add-GSChatCardSection -SectionHeader "Additional Info" -OutVariable sect2 |
     Send-GSChatMessage -Text "Got that report, boss:" -FallbackText "Mistakes have been made..." -Webhook ReportRoom
 
     This example shows the pipeline capabilities of the Chat functions in PSGSuite. Starting from top to bottom:
@@ -97,6 +97,7 @@ function Send-GSChatMessage {
 
     This gets the first 5 Services returned by Get-Service, creates KeyValue widgets for each, wraps it in a section with a header, then sends it to the Reports Webhook
     #>
+    [OutputType('Google.Apis.HangoutsChat.v1.Data.Message')]
     [cmdletbinding(DefaultParameterSetName = "Webhook")]
     Param
     (

--- a/PSGSuite/Public/Chat/Update-GSChatMessage.ps1
+++ b/PSGSuite/Public/Chat/Update-GSChatMessage.ps1
@@ -2,7 +2,7 @@ function Update-GSChatMessage {
     <#
     .SYNOPSIS
     Updates a Chat message, i.e. for a CardClicked response
-    
+
     .DESCRIPTION
     Updates a Chat message, i.e. for a CardClicked response
 
@@ -55,13 +55,13 @@ function Update-GSChatMessage {
     Add-GSChatKeyValue -TopLabel "Chocolate Budget" -Content '$5.00' -Icon DOLLAR |
     Add-GSChatKeyValue -TopLabel "Actual Spending" -Content '$5,000,000!' -BottomLabel "WTF" -Icon AIRPLANE |
     Add-GSChatImage -ImageUrl "https://media.tenor.com/images/f78545a9b520ecf953578b4be220f26d/tenor.gif" -LinkImage |
-    Add-GSChatCardSection -SectionHeader "Dollar bills, y'all" -OutVariable sect1 | 
-    Add-GSChatButton -Text "Launch nuke" -OnClick (Add-GSChatOnClick -Url "https://github.com/scrthq/PSGSuite") -Verbose -OutVariable button1 | 
-    Add-GSChatButton -Text "Unleash hounds" -OnClick (Add-GSChatOnClick -Url "https://admin.google.com/?hl=en&authuser=0") -Verbose -OutVariable button2 | 
-    Add-GSChatCardSection -SectionHeader "What should we do?" -OutVariable sect2 | 
+    Add-GSChatCardSection -SectionHeader "Dollar bills, y'all" -OutVariable sect1 |
+    Add-GSChatButton -Text "Launch nuke" -OnClick (Add-GSChatOnClick -Url "https://github.com/scrthq/PSGSuite") -Verbose -OutVariable button1 |
+    Add-GSChatButton -Text "Unleash hounds" -OnClick (Add-GSChatOnClick -Url "https://admin.google.com/?hl=en&authuser=0") -Verbose -OutVariable button2 |
+    Add-GSChatCardSection -SectionHeader "What should we do?" -OutVariable sect2 |
     Add-GSChatCard -HeaderTitle "Makin' moves with" -HeaderSubtitle "DEM GOODIES" -OutVariable card |
-    Add-GSChatTextParagraph -Text "This message sent by <b>PSGSuite</b> via WebHook!" | 
-    Add-GSChatCardSection -SectionHeader "Additional Info" -OutVariable sect2 | 
+    Add-GSChatTextParagraph -Text "This message sent by <b>PSGSuite</b> via WebHook!" |
+    Add-GSChatCardSection -SectionHeader "Additional Info" -OutVariable sect2 |
     Send-GSChatMessage -Text "Got that report, boss:" -FallbackText "Mistakes have been made..." -Webhook ReportRoom
 
     This example shows the pipeline capabilities of the Chat functions in PSGSuite. Starting from top to bottom:
@@ -85,6 +85,7 @@ function Update-GSChatMessage {
 
     This gets the first 5 Services returned by Get-Service, creates KeyValue widgets for each, wraps it in a section with a header, then sends it to the Reports Webhook
     #>
+    [OutputType('Google.Apis.HangoutsChat.v1.Data.Message')]
     [cmdletbinding(DefaultParameterSetName = "Update")]
     Param
     (

--- a/PSGSuite/Public/Classroom/Add-GSCourseParticipant.ps1
+++ b/PSGSuite/Public/Classroom/Add-GSCourseParticipant.ps1
@@ -33,6 +33,7 @@ function Add-GSCourseParticipant {
     .EXAMPLE
     Add-GSCourseParticipant -CourseId 'architecture-101' -Student plato@athens.edu,aristotle@athens.edu -Teacher zeus@athens.edu
     #>
+    [OutputType('Google.Apis.Classroom.v1.Data.Student')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Classroom/Get-GSClassroomUserProfile.ps1
+++ b/PSGSuite/Public/Classroom/Get-GSClassroomUserProfile.ps1
@@ -19,6 +19,7 @@ function Get-GSClassroomUserProfile {
     .EXAMPLE
     Get-GSClassroomUserProfile -UserId aristotle@athens.edu
     #>
+    [OutputType('Google.Apis.Classroom.v1.Data.UserProfile')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Classroom/Get-GSCourse.ps1
+++ b/PSGSuite/Public/Classroom/Get-GSCourse.ps1
@@ -34,6 +34,7 @@ function Get-GSCourse {
     .EXAMPLE
     Get-GSCourse -Teacher aristotle@athens.edu
     #>
+    [OutputType('Google.Apis.Classroom.v1.Data.Course')]
     [cmdletbinding(DefaultParameterSetName = "List")]
     Param
     (

--- a/PSGSuite/Public/Classroom/Get-GSCourseAlias.ps1
+++ b/PSGSuite/Public/Classroom/Get-GSCourseAlias.ps1
@@ -15,6 +15,7 @@ function Get-GSCourseAlias {
     .EXAMPLE
     Get-GSCourseAlias -CourseId 'architecture-101'
     #>
+    [OutputType('Google.Apis.Classroom.v1.Data.CourseAlias')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Classroom/Get-GSCourseInvitation.ps1
+++ b/PSGSuite/Public/Classroom/Get-GSCourseInvitation.ps1
@@ -25,6 +25,7 @@ function Get-GSCourseInvitation {
     .EXAMPLE
     Get-GSCourseInvitation -CourseId philosophy-101
     #>
+    [OutputType('Google.Apis.Classroom.v1.Data.Invitation')]
     [cmdletbinding(DefaultParameterSetName = "List")]
     Param
     (

--- a/PSGSuite/Public/Classroom/Get-GSCourseParticipant.ps1
+++ b/PSGSuite/Public/Classroom/Get-GSCourseParticipant.ps1
@@ -42,6 +42,7 @@ function Get-GSCourseParticipant {
     .EXAMPLE
     Get-GSCourseParticipant -Teacher aristotle@athens.edu
     #>
+    [OutputType('Google.Apis.Classroom.v1.Data.Student')]
     [cmdletbinding(DefaultParameterSetName = "List")]
     Param
     (

--- a/PSGSuite/Public/Classroom/Get-GSStudentGuardian.ps1
+++ b/PSGSuite/Public/Classroom/Get-GSStudentGuardian.ps1
@@ -26,6 +26,7 @@ function Get-GSStudentGuardian {
 
     Gets the list of guardians for all students.
     #>
+    [OutputType('Google.Apis.Classroom.v1.Data.Guardian')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Classroom/Get-GSStudentGuardianInvitation.ps1
+++ b/PSGSuite/Public/Classroom/Get-GSStudentGuardianInvitation.ps1
@@ -37,6 +37,7 @@ function Get-GSStudentGuardianInvitation {
 
     Gets the list of guardian invitations for this student.
     #>
+    [OutputType('Google.Apis.Classroom.v1.Data.GuardianInvitation')]
     [cmdletbinding(DefaultParameterSetName = "List")]
     Param
     (

--- a/PSGSuite/Public/Classroom/New-GSCourse.ps1
+++ b/PSGSuite/Public/Classroom/New-GSCourse.ps1
@@ -50,6 +50,7 @@ function New-GSCourse {
     .EXAMPLE
     New-GSCourse -Name "The Rebublic" -OwnerId plato@athens.edu -Id the-republic-s01 -Section s01 -DescriptionHeading "The definition of justice, the order and character of the just city-state and the just man" -Room academy-01
     #>
+    [OutputType('Google.Apis.Classroom.v1.Data.Course')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Classroom/New-GSCourseAlias.ps1
+++ b/PSGSuite/Public/Classroom/New-GSCourseAlias.ps1
@@ -27,6 +27,7 @@ function New-GSCourseAlias {
     .EXAMPLE
     New-GSCourseAlias -Alias "d:abc123" -CourseId 'architecture-101'
     #>
+    [OutputType('Google.Apis.Classroom.v1.Data.CourseAlias')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Classroom/New-GSCourseInvitation.ps1
+++ b/PSGSuite/Public/Classroom/New-GSCourseInvitation.ps1
@@ -29,6 +29,7 @@ function New-GSCourseInvitation {
     .EXAMPLE
     New-GSCourseInvitation -CourseId philosophy-101 -UserId aristotle@athens.edu -Role TEACHER
     #>
+    [OutputType('Google.Apis.Classroom.v1.Data.Invitation')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Classroom/New-GSStudentGuardianInvitation.ps1
+++ b/PSGSuite/Public/Classroom/New-GSStudentGuardianInvitation.ps1
@@ -31,6 +31,7 @@ function New-GSStudentGuardianInvitation {
     | aristotle@athens.edu | zeus@olympus.io |
     | plato@athens.edu     | hera@olympus.io |
     #>
+    [OutputType('Google.Apis.Classroom.v1.Data.GuardianInvitation')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Classroom/Update-GSCourse.ps1
+++ b/PSGSuite/Public/Classroom/Update-GSCourse.ps1
@@ -48,6 +48,7 @@ function Update-GSCourse {
     .EXAMPLE
     Update-GSCourse -Id the-republic-s01 -Name "The Rebublic 101"
     #>
+    [OutputType('Google.Apis.Classroom.v1.Data.Course')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Data Transfer/Get-GSDataTransferApplication.ps1
+++ b/PSGSuite/Public/Data Transfer/Get-GSDataTransferApplication.ps1
@@ -2,23 +2,24 @@
     <#
     .SYNOPSIS
     Gets the list of available Data Transfer Applications and their parameters
-    
+
     .DESCRIPTION
     Gets the list of available Data Transfer Applications and their parameters
-    
+
     .PARAMETER ApplicationId
     The Application Id of the Data Transfer Application you would like to return info for specifically. Exclude to return the full list
-    
+
     .PARAMETER PageSize
     PageSize of the result set.
 
     Defaults to 500 (although it's typically a much smaller number for most Customers)
-    
+
     .EXAMPLE
     Get-GSDataTransferApplication
 
     Gets the list of available Data Transfer Applications
     #>
+    [OutputType('Google.Apis.Admin.DataTransfer.datatransfer_v1.Data.Application')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Data Transfer/Start-GSDataTransfer.ps1
+++ b/PSGSuite/Public/Data Transfer/Start-GSDataTransfer.ps1
@@ -27,6 +27,7 @@
 
     Transfers all of Joe's data to Mark
     #>
+    [OutputType('Google.Apis.Admin.DataTransfer.datatransfer_v1.Data.DataTransfer')]
     [cmdletbinding()]
     Param (
         [parameter(Mandatory=$true,Position=0)]

--- a/PSGSuite/Public/Delegation/Add-GSGmailDelegate.ps1
+++ b/PSGSuite/Public/Delegation/Add-GSGmailDelegate.ps1
@@ -23,6 +23,7 @@
 
     Provide Peter delegate access to Tony's inbox.
     #>
+    [OutputType('Google.Apis.Gmail.v1.Data.Delegate')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Delegation/Get-GSGmailDelegate.ps1
+++ b/PSGSuite/Public/Delegation/Get-GSGmailDelegate.ps1
@@ -22,6 +22,7 @@
 
     Gets the list of users who have delegate access to Tony's inbox.
     #>
+    [OutputType('Google.Apis.Gmail.v1.Data.Delegate')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Drive/Add-GSDocContent.ps1
+++ b/PSGSuite/Public/Drive/Add-GSDocContent.ps1
@@ -2,21 +2,21 @@ function Add-GSDocContent {
     <#
     .SYNOPSIS
     Adds content to a Google Doc via appending new text. This does not overwrite existing content
-    
+
     .DESCRIPTION
     Adds content to a Google Doc via appending new text. This does not overwrite existing content
-    
+
     .PARAMETER FileID
     The unique Id of the file to add content to
-    
+
     .PARAMETER Value
     The content to add
-    
+
     .PARAMETER User
     The email or unique Id of the owner of the Drive file
 
     Defaults to the AdminEmail user
-    
+
     .EXAMPLE
     $newLogStrings | Add-GSDocContent -FileId '1rhsAYTOB_vrpvfwImPmWy0TcVa2sgmQa_9u976'
 
@@ -24,7 +24,7 @@ function Add-GSDocContent {
     #>
     [CmdLetBinding()]
     Param
-    (      
+    (
         [parameter(Mandatory = $true,Position = 0)]
         [String]
         $FileID,
@@ -72,7 +72,6 @@ function Add-GSDocContent {
             $request.SupportsTeamDrives = $true
             Write-Verbose "Adding content to File '$FileID'"
             $request.Upload() | Out-Null
-            $stream.Close()
         }
         catch {
             if ($ErrorActionPreference -eq 'Stop') {
@@ -80,6 +79,11 @@ function Add-GSDocContent {
             }
             else {
                 Write-Error $_
+            }
+        }
+        finally {
+            if ($stream) {
+                $stream.Close()
             }
         }
     }

--- a/PSGSuite/Public/Drive/Add-GSDrivePermission.ps1
+++ b/PSGSuite/Public/Drive/Add-GSDrivePermission.ps1
@@ -73,6 +73,7 @@ function Add-GSDrivePermission {
 
     Adds user joe@domain.com as the new owner of the file Id and sets the AdminEmail user as a Writer on the file
     #>
+    [OutputType('Google.Apis.Drive.v3.Data.Permission')]
     [cmdletbinding(SupportsShouldProcess = $true,ConfirmImpact = "High",DefaultParameterSetName = "Email")]
     Param
     (

--- a/PSGSuite/Public/Drive/Copy-GSDriveFile.ps1
+++ b/PSGSuite/Public/Drive/Copy-GSDriveFile.ps1
@@ -40,6 +40,7 @@ function Copy-GSDriveFile {
 
     Copies the Drive file Id to a new Drive file named 'New Daily Checklist'
     #>
+    [OutputType('Google.Apis.Drive.v3.Data.File')]
     [cmdletbinding(DefaultParameterSetName = "Depth")]
     Param
     (

--- a/PSGSuite/Public/Drive/Get-GSDriveFile.ps1
+++ b/PSGSuite/Public/Drive/Get-GSDriveFile.ps1
@@ -39,6 +39,7 @@ function Get-GSDriveFile {
 
     Gets the information for the file and saves the file in the current working directory
     #>
+    [OutputType('Google.Apis.Drive.v3.Data.File')]
     [cmdletbinding(DefaultParameterSetName = "Depth")]
     Param
     (

--- a/PSGSuite/Public/Drive/Get-GSDriveFileList.ps1
+++ b/PSGSuite/Public/Drive/Get-GSDriveFileList.ps1
@@ -2,46 +2,47 @@ function Get-GSDriveFileList {
     <#
     .SYNOPSIS
     Gets the list of Drive files owned by the user
-    
+
     .DESCRIPTION
     Gets the list of Drive files owned by the user
-    
+
     .PARAMETER User
     The email or unique Id of the user whose Drive files you are trying to list
 
     Defaults to the AdminEmail user
-    
+
     .PARAMETER Filter
     A query for filtering the file results. See the "Search for Files and Team Drives" guide for the supported syntax: https://developers.google.com/drive/v3/web/search-parameters
 
     PowerShell filter syntax here is supported as "best effort". Please use Google's filter operators and syntax to ensure best results
-    
+
     .PARAMETER TeamDriveId
     ID of Team Drive to search
-    
+
     .PARAMETER ParentFolderId
     ID of parent folder to search to add to the filter
-    
+
     .PARAMETER IncludeTeamDriveItems
     Whether Team Drive items should be included in results. (Default: false)
-    
+
     .PARAMETER Corpora
     Comma-separated list of bodies of items (files/documents) to which the query applies. Supported bodies are 'User', 'Domain', 'TeamDrive' and 'AllTeamDrives'. 'AllTeamDrives' must be combined with 'User'; all other values must be used in isolation. Prefer 'User' or 'TeamDrive' to 'AllTeamDrives' for efficiency.
-    
+
     .PARAMETER Spaces
     A comma-separated list of spaces to query within the corpus. Supported values are 'Drive', 'AppDataFolder' and 'Photos'.
-    
+
     .PARAMETER OrderBy
     A comma-separated list of sort keys. Valid keys are 'createdTime', 'folder', 'modifiedByMeTime', 'modifiedTime', 'name', 'name_natural', 'quotaBytesUsed', 'recency', 'sharedWithMeTime', 'starred', and 'viewedByMeTime'.
-    
+
     .PARAMETER PageSize
     The page size of the result set
-    
+
     .EXAMPLE
     Get-GSDriveFileList joe
 
     Gets Joe's Drive file list
     #>
+    [OutputType('Google.Apis.Drive.v3.Data.File')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Drive/Get-GSDrivePermission.ps1
+++ b/PSGSuite/Public/Drive/Get-GSDrivePermission.ps1
@@ -2,39 +2,40 @@ function Get-GSDrivePermission {
     <#
     .SYNOPSIS
     Gets permission information for a Drive file
-    
+
     .DESCRIPTION
     Gets permission information for a Drive file
-    
+
     .PARAMETER User
     The email or unique Id of the user whose Drive file permission you are trying to get
 
     Defaults to the AdminEmail user
-    
+
     .PARAMETER FileId
     The unique Id of the Drive file
-    
+
     .PARAMETER PermissionId
     The unique Id of the permission you are trying to get. If excluded, the list of permissions for the Drive file will be returned instead
-    
+
     .PARAMETER PageSize
     The page size of the result set
-    
+
     .EXAMPLE
     Get-GSDrivePermission -FileId '1rhsAYTOB_vrpvfwImPmWy0TcVa2sgmQa_9u976'
 
     Gets the list of permissions for the file Id
     #>
+    [OutputType('Google.Apis.Drive.v3.Data.Permission')]
     [cmdletbinding(DefaultParameterSetName = "List")]
     Param
     (
         [parameter(Mandatory = $false,Position = 0,ValueFromPipelineByPropertyName = $true)]
         [Alias('Owner','PrimaryEmail','UserKey','Mail')]
         [string]
-        $User = $Script:PSGSuite.AdminEmail, 
+        $User = $Script:PSGSuite.AdminEmail,
         [parameter(Mandatory = $true)]
         [String]
-        $FileId, 
+        $FileId,
         [parameter(Mandatory = $false,ParameterSetName = "Get")]
         [String[]]
         $PermissionId,

--- a/PSGSuite/Public/Drive/Get-GSDriveProfile.ps1
+++ b/PSGSuite/Public/Drive/Get-GSDriveProfile.ps1
@@ -2,20 +2,21 @@ function Get-GSDriveProfile {
     <#
     .SYNOPSIS
     Gets Drive profile for the user
-    
+
     .DESCRIPTION
     Gets Drive profile for the user
-    
+
     .PARAMETER User
     The user to get profile of
 
     Defaults to the AdminEmail user
-    
+
     .EXAMPLE
     Get-GSDriveProfile
 
     Gets the Drive profile of the AdminEmail user
     #>
+    [OutputType('Google.Apis.Drive.v3.Data.About')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Drive/Get-GSTeamDrive.ps1
+++ b/PSGSuite/Public/Drive/Get-GSTeamDrive.ps1
@@ -2,27 +2,28 @@ function Get-GSTeamDrive {
     <#
     .SYNOPSIS
     Gets information about a Team Drive
-    
+
     .DESCRIPTION
     Gets information about a Team Drive
-    
+
     .PARAMETER TeamDriveId
     The unique Id of the Team Drive. If excluded, the list of Team Drives will be returned
-    
+
     .PARAMETER User
     The email or unique Id of the user with access to the Team Drive
-    
+
     .PARAMETER Filter
     Query string for searching Team Drives. See the "Search for Files and Team Drives" guide for the supported syntax: https://developers.google.com/drive/v3/web/search-parameters
 
     PowerShell filter syntax here is supported as "best effort". Please use Google's filter operators and syntax to ensure best results
-    
+
     .PARAMETER PageSize
     The page size of the result set
-    
+
     .EXAMPLE
-    
+
     #>
+    [OutputType('Google.Apis.Drive.v3.Data.TeamDrive')]
     [cmdletbinding(DefaultParameterSetName = "List")]
     Param
     (

--- a/PSGSuite/Public/Drive/New-GSDriveFile.ps1
+++ b/PSGSuite/Public/Drive/New-GSDriveFile.ps1
@@ -57,6 +57,7 @@ function New-GSDriveFile {
 
     Creates a new folder in Drive named "Training Docs" in the root OrgUnit for the AdminEmail user
     #>
+    [OutputType('Google.Apis.Drive.v3.Data.File')]
     [cmdletbinding(DefaultParameterSetName = "BuiltIn")]
     Param
     (

--- a/PSGSuite/Public/Drive/New-GSTeamDrive.ps1
+++ b/PSGSuite/Public/Drive/New-GSTeamDrive.ps1
@@ -2,66 +2,67 @@ function New-GSTeamDrive {
     <#
     .SYNOPSIS
     Creates a new Team Drive
-    
+
     .DESCRIPTION
     Creates a new Team Drive
-    
+
     .PARAMETER Name
     The name of the Team Drive
-    
+
     .PARAMETER User
     The user to create the Team Drive for (must have permissions to create Team Drives)
-    
+
     .PARAMETER RequestId
     An ID, such as a random UUID, which uniquely identifies this user's request for idempotent creation of a Team Drive. A repeated request by the same user and with the same request ID will avoid creating duplicates by attempting to create the same Team Drive. If the Team Drive already exists a 409 error will be returned.
-    
+
     .PARAMETER CanAddChildren
     Whether the current user can add children to folders in this Team Drive
-    
+
     .PARAMETER CanChangeTeamDriveBackground
     Whether the current user can change the background of this Team Drive
-    
+
     .PARAMETER CanComment
     Whether the current user can comment on files in this Team Drive
-    
+
     .PARAMETER CanCopy
     Whether the current user can copy files in this Team Drive
-    
+
     .PARAMETER CanDeleteTeamDrive
     Whether the current user can delete this Team Drive. Attempting to delete the Team Drive may still fail if there are untrashed items inside the Team Drive
-    
+
     .PARAMETER CanDownload
     Whether the current user can download files in this Team Drive
-    
+
     .PARAMETER CanEdit
     Whether the current user can edit files in this Team Drive
-    
+
     .PARAMETER CanListChildren
     Whether the current user can list the children of folders in this Team Drive
-    
+
     .PARAMETER CanManageMembers
     Whether the current user can add members to this Team Drive or remove them or change their role
-    
+
     .PARAMETER CanReadRevisions
     Whether the current user can read the revisions resource of files in this Team Drive
-    
+
     .PARAMETER CanRemoveChildren
     Whether the current user can remove children from folders in this Team Drive
-    
+
     .PARAMETER CanRename
     Whether the current user can rename files or folders in this Team Drive
-    
+
     .PARAMETER CanRenameTeamDrive
     Whether the current user can rename this Team Drive
-    
+
     .PARAMETER CanShare
     Whether the current user can share files or folders in this Team Drive
-    
+
     .EXAMPLE
     New-GSTeamDrive -Name "Training Docs"
 
     Creates a new Team Drive named "Training Docs"
     #>
+    [OutputType('Google.Apis.Drive.v3.Data.TeamDrive')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Drive/Update-GSDriveFile.ps1
+++ b/PSGSuite/Public/Drive/Update-GSDriveFile.ps1
@@ -2,28 +2,28 @@ function Update-GSDriveFile {
     <#
     .SYNOPSIS
     Updates the metadata for a Drive file
-    
+
     .DESCRIPTION
     Updates the metadata for a Drive file
-    
+
     .PARAMETER FileId
     The unique Id of the Drive file to Update
-    
+
     .PARAMETER Path
     The path to the local file whose content you would like to upload to Drive.
-    
+
     .PARAMETER Name
     The new name of the Drive file
-    
+
     .PARAMETER Description
     The new description of the Drive file
-    
+
     .PARAMETER AddParents
     The parent Ids to add
-    
+
     .PARAMETER RemoveParents
     The parent Ids to remove
-    
+
     .PARAMETER Projection
     The defined subset of fields to be returned
 
@@ -32,23 +32,24 @@ function Update-GSDriveFile {
     * "Standard"
     * "Full"
     * "Access"
-    
+
     .PARAMETER Fields
     The specific fields to returned
-    
+
     .PARAMETER User
     The email or unique Id of the Drive file owner
-    
+
     .EXAMPLE
     Update-GSDriveFile -FileId '1rhsAYTOB_vrpvfwImPmWy0TcVa2sgmQa_9u976' -Name "To-Do Progress"
 
     Updates the Drive file with a new name, "To-Do Progress"
-    
+
     .EXAMPLE
     Update-GSDriveFile -FileId '1rhsAYTOB_vrpvfwImPmWy0TcVa2sgmQa_9u976' -Path "C:\Pics\NewPic.png"
 
     Updates the Drive file with the content of the file at that path. In this example, the Drive file is a PNG named "Test.png". This will change the content of the file in Drive to match NewPic.png as well as rename it to "NewPic.png"
     #>
+    [OutputType('Google.Apis.Drive.v3.Data.File')]
     [cmdletbinding(DefaultParameterSetName = "Depth")]
     Param
     (

--- a/PSGSuite/Public/Drive/Update-GSTeamDrive.ps1
+++ b/PSGSuite/Public/Drive/Update-GSTeamDrive.ps1
@@ -2,66 +2,67 @@ function Update-GSTeamDrive {
     <#
     .SYNOPSIS
     Update metatdata for a Team Drive
-    
+
     .DESCRIPTION
     Update metatdata for a Team Drive
-    
+
     .PARAMETER TeamDriveId
     The unique Id of the Team Drive to update
-    
+
     .PARAMETER User
     The user to create the Team Drive for (must have permissions to create Team Drives)
-    
+
     .PARAMETER Name
     The name of the Team Drive
-    
+
     .PARAMETER CanAddChildren
     Whether the current user can add children to folders in this Team Drive
-    
+
     .PARAMETER CanChangeTeamDriveBackground
     Whether the current user can change the background of this Team Drive
-    
+
     .PARAMETER CanComment
     Whether the current user can comment on files in this Team Drive
-    
+
     .PARAMETER CanCopy
     Whether the current user can copy files in this Team Drive
-    
+
     .PARAMETER CanDeleteTeamDrive
     Whether the current user can delete this Team Drive. Attempting to delete the Team Drive may still fail if there are untrashed items inside the Team Drive
-    
+
     .PARAMETER CanDownload
     Whether the current user can download files in this Team Drive
-    
+
     .PARAMETER CanEdit
     Whether the current user can edit files in this Team Drive
-    
+
     .PARAMETER CanListChildren
     Whether the current user can list the children of folders in this Team Drive
-    
+
     .PARAMETER CanManageMembers
     Whether the current user can add members to this Team Drive or remove them or change their role
-    
+
     .PARAMETER CanReadRevisions
     Whether the current user can read the revisions resource of files in this Team Drive
-    
+
     .PARAMETER CanRemoveChildren
     Whether the current user can remove children from folders in this Team Drive
-    
+
     .PARAMETER CanRename
     Whether the current user can rename files or folders in this Team Drive
-    
+
     .PARAMETER CanRenameTeamDrive
     Whether the current user can rename this Team Drive
-    
+
     .PARAMETER CanShare
     Whether the current user can share files or folders in this Team Drive
-    
+
     .EXAMPLE
     Update-GSTeamDrive -TeamDriveId '0AJ8Xjq3FcdCKUk9PVA' -Name "HR Document Repo"
 
     Updated the Team Drive with a new name, "HR Document Repo"
     #>
+    [OutputType('Google.Apis.Drive.v3.Data.TeamDrive')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Gmail/Add-GSGmailFilter.ps1
+++ b/PSGSuite/Public/Gmail/Add-GSGmailFilter.ps1
@@ -2,62 +2,63 @@
     <#
     .SYNOPSIS
     Adds a new Gmail filter
-    
+
     .DESCRIPTION
     Adds a new Gmail filter
-    
+
     .PARAMETER User
     The email of the user you are adding the filter for
-    
+
     .PARAMETER From
     The sender's display name or email address.
-    
+
     .PARAMETER To
     The recipient's display name or email address. Includes recipients in the "to", "cc", and "bcc" header fields. You can use simply the local part of the email address. For example, "example" and "example@" both match "example@gmail.com". This field is case-insensitive
-    
+
     .PARAMETER Subject
     Case-insensitive phrase found in the message's subject. Trailing and leading whitespace are be trimmed and adjacent spaces are collapsed
-    
+
     .PARAMETER Query
     Only return messages matching the specified query. Supports the same query format as the Gmail search box. For example, "from:someuser@example.com rfc822msgid: is:unread"
-    
+
     .PARAMETER NegatedQuery
     Only return messages not matching the specified query. Supports the same query format as the Gmail search box. For example, "from:someuser@example.com rfc822msgid: is:unread"
-    
+
     .PARAMETER HasAttachment
     Whether the message has any attachment
-    
+
     .PARAMETER ExcludeChats
     Whether the response should exclude chats
-    
+
     .PARAMETER AddLabelIDs
     List of labels to add to the message
-    
+
     .PARAMETER RemoveLabelIDs
     List of labels to remove from the message
-    
+
     .PARAMETER Forward
     Email address that the message should be forwarded to
-    
+
     .PARAMETER Size
     The size of the entire RFC822 message in bytes, including all headers and attachments
-    
+
     .PARAMETER SizeComparison
-    How the message size in bytes should be in relation to the size field. 
+    How the message size in bytes should be in relation to the size field.
 
     Acceptable values are:
     * "larger"
     * "smaller"
     * "unspecified"
-    
+
     .PARAMETER Raw
     If $true, returns the raw response. If not passed or -Raw:$false, response is formatted as a flat object for readability
-    
+
     .EXAMPLE
     Add-GSGmailFilter -To admin@domain.com -ExcludeChats -Forward "admin_directMail@domain.com"
 
     Adds a filter for the AdminEmail user to forward all mail sent directly to the to "admin_directMail@domain.com"
     #>
+    [OutputType('Google.Apis.Gmail.v1.Data.Filter')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Gmail/Add-GSGmailForwardingAddress.ps1
+++ b/PSGSuite/Public/Gmail/Add-GSGmailForwardingAddress.ps1
@@ -2,23 +2,24 @@ function Add-GSGmailForwardingAddress {
     <#
     .SYNOPSIS
     Creates a forwarding address.
-    
+
     .DESCRIPTION
     Creates a forwarding address. If ownership verification is required, a message will be sent to the recipient and the resource's verification status will be set to pending; otherwise, the resource will be created with verification status set to accepted.
-    
+
     .PARAMETER ForwardingAddress
-    An email address to which messages can be forwarded. 
-    
+    An email address to which messages can be forwarded.
+
     .PARAMETER User
     The user to create the forwarding addresses for
 
     Defaults to the AdminEmail user
-    
+
     .EXAMPLE
     Add-GSGmailForwardingAddress "joe@domain.com"
 
     Adds joe@domain.com as a forwarding address for the AdminEmail user
     #>
+    [OutputType('Google.Apis.Gmail.v1.Data.ForwardingAddress')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Gmail/Get-GSGmailAutoForwardingSettings.ps1
+++ b/PSGSuite/Public/Gmail/Get-GSGmailAutoForwardingSettings.ps1
@@ -2,20 +2,21 @@ function Get-GSGmailAutoForwardingSettings {
     <#
     .SYNOPSIS
     Gets AutoForwarding settings
-    
+
     .DESCRIPTION
     Gets AutoForwarding settings
-    
+
     .PARAMETER User
     The user to get the AutoForwarding settings for
 
     Defaults to the AdminEmail user
-    
+
     .EXAMPLE
     Get-GSGmailAutoForwardingSettings
 
     Gets the AutoForwarding settings for the AdminEmail user
     #>
+    [OutputType('Google.Apis.Gmail.v1.Data.AutoForwarding')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Gmail/Get-GSGmailFilter.ps1
+++ b/PSGSuite/Public/Gmail/Get-GSGmailFilter.ps1
@@ -2,24 +2,25 @@ function Get-GSGmailFilter {
     <#
     .SYNOPSIS
     Gets Gmail filter details
-    
+
     .DESCRIPTION
     Gets Gmail filter details
-    
+
     .PARAMETER FilterId
     The unique Id of the filter you would like to retrieve information for. If excluded, all filters for the user are returned
-    
+
     .PARAMETER User
     The email of the user you are getting the filter information for
-    
+
     .PARAMETER Raw
     If $true, returns the raw response. If not passed or -Raw:$false, response is formatted as a flat object for readability
-    
+
     .EXAMPLE
     Get-GSGmailFilter -User joe
 
     Gets the list of filters for Joe
     #>
+    [OutputType('Google.Apis.Gmail.v1.Data.Filter')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Gmail/Get-GSGmailForwardingAddress.ps1
+++ b/PSGSuite/Public/Gmail/Get-GSGmailForwardingAddress.ps1
@@ -2,23 +2,24 @@ function Get-GSGmailForwardingAddress {
     <#
     .SYNOPSIS
     Gets Gmail forwarding address information for the user
-    
+
     .DESCRIPTION
     Gets Gmail forwarding address information for the user
-    
+
     .PARAMETER ForwardingAddress
     The forwarding address you would like to get info for. If excluded, gets the list of forwarding addresses and their info for the user
-    
+
     .PARAMETER User
     The user to get the forwarding addresses for
 
     Defaults to the AdminEmail user
-    
+
     .EXAMPLE
     Get-GSGmailForwardingAddress
 
     Gets the list of forwarding addresses for the AdminEmail user
     #>
+    [OutputType('Google.Apis.Gmail.v1.Data.ForwardingAddress')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Gmail/Get-GSGmailImapSettings.ps1
+++ b/PSGSuite/Public/Gmail/Get-GSGmailImapSettings.ps1
@@ -2,20 +2,21 @@ function Get-GSGmailImapSettings {
     <#
     .SYNOPSIS
     Gets IMAP settings
-    
+
     .DESCRIPTION
     Gets IMAP settings
-    
+
     .PARAMETER User
     The user to get the IMAP settings for
 
     Defaults to the AdminEmail user
-    
+
     .EXAMPLE
     Get-GSGmailImapSettings
 
     Gets the IMAP settings for the AdminEmail user
     #>
+    [OutputType('Google.Apis.Gmail.v1.Data.ImapSettings')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Gmail/Get-GSGmailLabel.ps1
+++ b/PSGSuite/Public/Gmail/Get-GSGmailLabel.ps1
@@ -2,23 +2,24 @@ function Get-GSGmailLabel {
     <#
     .SYNOPSIS
     Gets Gmail label information for the user
-    
+
     .DESCRIPTION
     Gets Gmail label information for the user
-    
+
     .PARAMETER LabelId
     The unique Id of the label to get information for. If excluded, returns the list of labels for the user
-    
+
     .PARAMETER User
     The user to get label information for
 
     Defaults to the AdminEmail user
-    
+
     .EXAMPLE
     Get-GSGmailLabel
 
     Gets the Gmail labels of the AdminEmail user
     #>
+    [OutputType('Google.Apis.Gmail.v1.Data.Label')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Gmail/Get-GSGmailMessage.ps1
+++ b/PSGSuite/Public/Gmail/Get-GSGmailMessage.ps1
@@ -2,24 +2,24 @@ function Get-GSGmailMessage {
     <#
     .SYNOPSIS
     Gets Gmail message details
-    
+
     .DESCRIPTION
     Gets Gmail message details
-    
+
     .PARAMETER User
     The primary email of the user who owns the message
 
     Defaults to the AdminEmail user
-    
+
     .PARAMETER Id
     The Id of the message to retrieve info for
-    
+
     .PARAMETER ParseMessage
     If $true, returns the parsed raw message
-    
+
     .PARAMETER SaveAttachmentsTo
     If the message has attachments, the path to save the attachments to. If excluded, attachments are not saved locally
-    
+
     .PARAMETER Format
     The format of the message metadata to retrieve
 
@@ -30,12 +30,13 @@ function Get-GSGmailMessage {
     * "Raw"
 
     Defaults to "Full", but forces -Format as "Raw" if -ParseMessage or -SaveAttachmentsTo are used
-    
+
     .EXAMPLE
     Get-GSGmailMessage -Id 1615f9a6ee36cb5b -ParseMessage
 
     Gets the full message details for the provided Id and parses out the raw MIME message content
     #>
+    [OutputType('Google.Apis.Gmail.v1.Data.Message')]
     [cmdletbinding(DefaultParameterSetName = "Format")]
     Param
     (

--- a/PSGSuite/Public/Gmail/Get-GSGmailMessageList.ps1
+++ b/PSGSuite/Public/Gmail/Get-GSGmailMessageList.ps1
@@ -33,6 +33,7 @@ function Get-GSGmailMessageList {
 
     Gets the list of messages sent directly to the user after 2017/12/25 excluding chats
     #>
+    [OutputType('Google.Apis.Gmail.v1.Data.Message')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Gmail/Get-GSGmailPopSettings.ps1
+++ b/PSGSuite/Public/Gmail/Get-GSGmailPopSettings.ps1
@@ -2,20 +2,21 @@ function Get-GSGmailPopSettings {
     <#
     .SYNOPSIS
     Gets POP settings
-    
+
     .DESCRIPTION
     Gets POP settings
-    
+
     .PARAMETER User
     The user to get the POP settings for
 
     Defaults to the AdminEmail user
-    
+
     .EXAMPLE
     Get-GSGmailPopSettings
 
     Gets the POP settings for the AdminEmail user
     #>
+    [OutputType('Google.Apis.Gmail.v1.Data.PopSettings')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Gmail/Get-GSGmailProfile.ps1
+++ b/PSGSuite/Public/Gmail/Get-GSGmailProfile.ps1
@@ -2,20 +2,21 @@ function Get-GSGmailProfile {
     <#
     .SYNOPSIS
     Gets Gmail profile for the user
-    
+
     .DESCRIPTION
     Gets Gmail profile for the user
-    
+
     .PARAMETER User
     The user to get profile of
 
     Defaults to the AdminEmail user
-    
+
     .EXAMPLE
     Get-GSGmailProfile
 
     Gets the Gmail profile of the AdminEmail user
     #>
+    [OutputType('Google.Apis.Gmail.v1.Data.Profile')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Gmail/Get-GSGmailSMIMEInfo.ps1
+++ b/PSGSuite/Public/Gmail/Get-GSGmailSMIMEInfo.ps1
@@ -2,28 +2,29 @@ function Get-GSGmailSMIMEInfo {
     <#
     .SYNOPSIS
     Gets Gmail S/MIME info
-    
+
     .DESCRIPTION
     Gets Gmail S/MIME info
-    
+
     .PARAMETER SendAsEmail
     The email address that appears in the "From:" header for mail sent using this alias.
-    
+
     .PARAMETER Id
     The immutable ID for the SmimeInfo.
 
     If left blank, returns the list of S/MIME infos for the SendAsEmail and User
-    
+
     .PARAMETER User
     The user's email address
 
     Defaults to the AdminEmail user
-    
+
     .EXAMPLE
     Get-GSGmailSMIMEInfo -SendAsEmail 'joe@otherdomain.com' -User joe@domain.com
 
     Gets the list of S/MIME infos for Joe's SendAsEmail 'joe@otherdomain.com'
     #>
+    [OutputType('Google.Apis.Gmail.v1.Data.SmimeInfo')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Gmail/Get-GSGmailVacationSettings.ps1
+++ b/PSGSuite/Public/Gmail/Get-GSGmailVacationSettings.ps1
@@ -2,20 +2,21 @@ function Get-GSGmailVacationSettings {
     <#
     .SYNOPSIS
     Gets Vacation settings
-    
+
     .DESCRIPTION
     Gets Vacation settings
-    
+
     .PARAMETER User
     The user to get the Vacation settings for
 
     Defaults to the AdminEmail user
-    
+
     .EXAMPLE
     Get-GSGmailVacationSettings
 
     Gets the Vacation settings for the AdminEmail user
     #>
+    [OutputType('Google.Apis.Gmail.v1.Data.VacationSettings')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Gmail/New-GSGmailLabel.ps1
+++ b/PSGSuite/Public/Gmail/New-GSGmailLabel.ps1
@@ -174,6 +174,7 @@ function New-GSGmailLabel {
 
     Adds the label "Label1" to the AdminEmail
     #>
+    [OutputType('Google.Apis.Gmail.v1.Data.Label')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Gmail/New-GSGmailSMIMEInfo.ps1
+++ b/PSGSuite/Public/Gmail/New-GSGmailSMIMEInfo.ps1
@@ -2,30 +2,31 @@ function New-GSGmailSMIMEInfo {
     <#
     .SYNOPSIS
     Adds Gmail S/MIME info
-    
+
     .DESCRIPTION
     Adds Gmail S/MIME info
-    
+
     .PARAMETER SendAsEmail
     The email address that appears in the "From:" header for mail sent using this alias.
-    
+
     .PARAMETER Pkcs12
     PKCS#12 format containing a single private/public key pair and certificate chain. This format is only accepted from client for creating a new SmimeInfo and is never returned, because the private key is not intended to be exported. PKCS#12 may be encrypted, in which case encryptedKeyPassword should be set appropriately.
-    
+
     .PARAMETER EncryptedKeyPassword
     Encrypted key password, when key is encrypted.
 
     .PARAMETER IsDefault
     Whether this SmimeInfo is the default one for this user's send-as address.
-    
+
     .PARAMETER User
     The user's email address
-    
+
     .EXAMPLE
     New-GSGmailSMIMEInfo -SendAsEmail 'joe@otherdomain.com' -Pkcs12 .\MyCert.pfx -User joe@domain.com
 
     Creates a specified S/MIME for Joe's SendAsEmail 'joe@otherdomain.com' using the provided PKCS12 certificate
     #>
+    [OutputType('Google.Apis.Gmail.v1.Data.SmimeInfo')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Gmail/Update-GSGmailAutoForwardingSettings.ps1
+++ b/PSGSuite/Public/Gmail/Update-GSGmailAutoForwardingSettings.ps1
@@ -1,16 +1,16 @@
 function Update-GSGmailAutoForwardingSettings {
     <#
     .SYNOPSIS
-    Updates the auto-forwarding setting for the specified account. A verified forwarding address must be specified when auto-forwarding is enabled. 
-    
+    Updates the auto-forwarding setting for the specified account. A verified forwarding address must be specified when auto-forwarding is enabled.
+
     .DESCRIPTION
     Updates the auto-forwarding setting for the specified account. A verified forwarding address must be specified when auto-forwarding is enabled.
-    
+
     .PARAMETER User
     The user to update the AutoForwarding settings for
-    
+
     .PARAMETER Disposition
-    The state that a message should be left in after it has been forwarded. 
+    The state that a message should be left in after it has been forwarded.
 
     Acceptable values are:
     * "archive": Archive the message.
@@ -18,18 +18,19 @@ function Update-GSGmailAutoForwardingSettings {
     * "leaveInInbox": Leave the message in the INBOX.
     * "markRead": Leave the message in the INBOX and mark it as read.
     * "trash": Move the message to the TRASH.
-    
+
     .PARAMETER EmailAddress
     Email address to which all incoming messages are forwarded. This email address must be a verified member of the forwarding addresses.
-    
+
     .PARAMETER Enabled
     Whether all incoming mail is automatically forwarded to another address.
-    
+
     .EXAMPLE
     Update-GSGmailAutoForwardingSettings -User me -Disposition leaveInInbox -EmailAddress joe@domain.com -Enabled
 
     Enables auto forwarding of all mail for the AdminEmail user. Forwarded mail will be left in their inbox.
     #>
+    [OutputType('Google.Apis.Gmail.v1.Data.AutoForwarding')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Gmail/Update-GSGmailImapSettings.ps1
+++ b/PSGSuite/Public/Gmail/Update-GSGmailImapSettings.ps1
@@ -2,36 +2,37 @@ function Update-GSGmailImapSettings {
     <#
     .SYNOPSIS
     Updates IMAP settings
-    
+
     .DESCRIPTION
     Updates IMAP settings
-    
+
     .PARAMETER User
     The user to update the IMAP settings for
-    
+
     .PARAMETER AutoExpunge
     If this value is true, Gmail will immediately expunge a message when it is marked as deleted in IMAP. Otherwise, Gmail will wait for an update from the client before expunging messages marked as deleted.
-    
+
     .PARAMETER Enabled
     Whether IMAP is enabled for the account.
-    
+
     .PARAMETER ExpungeBehavior
-    The action that will be executed on a message when it is marked as deleted and expunged from the last visible IMAP folder. 
+    The action that will be executed on a message when it is marked as deleted and expunged from the last visible IMAP folder.
 
     Acceptable values are:
     * "archive": Archive messages marked as deleted.
     * "deleteForever": Immediately and permanently delete messages marked as deleted. The expunged messages cannot be recovered.
     * "expungeBehaviorUnspecified": Unspecified behavior.
     * "trash": Move messages marked as deleted to the trash.
-    
+
     .PARAMETER MaxFolderSize
     An optional limit on the number of messages that an IMAP folder may contain. Legal values are 0, 1000, 2000, 5000 or 10000. A value of zero is interpreted to mean that there is no limit.
-    
+
     .EXAMPLE
     Update-GSGmailImapSettings -Enabled:$false -User me
 
     Disables IMAP for the AdminEmail user
     #>
+    [OutputType('Google.Apis.Gmail.v1.Data.ImapSettings')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Gmail/Update-GSGmailLabel.ps1
+++ b/PSGSuite/Public/Gmail/Update-GSGmailLabel.ps1
@@ -182,6 +182,7 @@ function Update-GSGmailLabel {
 
     Updates all labels with LabelListVisibility of 'labelShowIfUnread' with new background and text colors and sets all of them to always show
     #>
+    [OutputType('Google.Apis.Gmail.v1.Data.Label')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Gmail/Update-GSGmailPopSettings.ps1
+++ b/PSGSuite/Public/Gmail/Update-GSGmailPopSettings.ps1
@@ -2,24 +2,24 @@ function Update-GSGmailPopSettings {
     <#
     .SYNOPSIS
     Updates POP settings
-    
+
     .DESCRIPTION
     Updates POP settings
-    
+
     .PARAMETER User
     The user to update the POP settings for
-    
+
     .PARAMETER AccessWindow
-    The range of messages which are accessible via POP. 
+    The range of messages which are accessible via POP.
 
     Acceptable values are:
     * "accessWindowUnspecified": Unspecified range.
     * "allMail": Indicates that all unfetched messages are accessible via POP.
     * "disabled": Indicates that no messages are accessible via POP.
     * "fromNowOn": Indicates that unfetched messages received after some past point in time are accessible via POP.
-    
+
     .PARAMETER Disposition
-    The action that will be executed on a message after it has been fetched via POP. 
+    The action that will be executed on a message after it has been fetched via POP.
 
     Acceptable values are:
     * "archive": Archive the message.
@@ -27,12 +27,13 @@ function Update-GSGmailPopSettings {
     * "leaveInInbox": Leave the message in the INBOX.
     * "markRead": Leave the message in the INBOX and mark it as read.
     * "trash": Move the message to the TRASH.
-    
+
     .EXAMPLE
     Update-GSGmailPopSettings -User me -AccessWindow allMail
 
     Sets the POP AccessWindow to 'allMail' for the AdminEmail user
     #>
+    [OutputType('Google.Apis.Gmail.v1.Data.PopSettings')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Gmail/Update-GSGmailVacationSettings.ps1
+++ b/PSGSuite/Public/Gmail/Update-GSGmailVacationSettings.ps1
@@ -1,48 +1,49 @@
 function Update-GSGmailVacationSettings {
     <#
     .SYNOPSIS
-    Updates vacation responder settings for the specified account. 
-    
+    Updates vacation responder settings for the specified account.
+
     .DESCRIPTION
     Updates vacation responder settings for the specified account.
-    
+
     .PARAMETER User
     The user to update the VacationSettings settings for
-    
+
     .PARAMETER EnableAutoReply
     Flag that controls whether Gmail automatically replies to messages.
-    
+
     .PARAMETER EndTime
     An optional end time for sending auto-replies. When this is specified, Gmail will automatically reply only to messages that it receives before the end time. If both startTime and endTime are specified, startTime must precede endTime.
-    
+
     .PARAMETER ResponseBodyHtml
     Response body in HTML format. Gmail will sanitize the HTML before storing it.
-    
+
     .PARAMETER ResponseBodyPlainText
     Response body in plain text format.
-    
+
     .PARAMETER ResponseSubject
     Optional text to prepend to the subject line in vacation responses. In order to enable auto-replies, either the response subject or the response body must be nonempty.
-    
+
     .PARAMETER RestrictToContacts
     Flag that determines whether responses are sent to recipients who are not in the user's list of contacts.
-    
+
     .PARAMETER RestrictToDomain
     Flag that determines whether responses are sent to recipients who are outside of the user's domain. This feature is only available for G Suite users.
-    
+
     .PARAMETER StartTime
     An optional start time for sending auto-replies. When this is specified, Gmail will automatically reply only to messages that it receives after the start time. If both startTime and endTime are specified, startTime must precede endTime.
-    
+
     .EXAMPLE
     Update-GSGmailVacationSettings -User me -ResponseBodyHtml "I'm on vacation and will reply when I'm back in the office. Thanks!" -RestrictToDomain -EndTime (Get-Date).AddDays(7) -StartTime (Get-Date) -EnableAutoReply
 
     Enables the vacation auto-reply for the AdminEmail user. Auto-replies will be sent to other users in the same domain only. The vacation response is enabled for 7 days from the time that the command is sent.
-    
+
     .EXAMPLE
     Update-GSGmailVacationSettings -User me -EnableAutoReply:$false
 
     Disables the vacaction auto-response for the AdminEmail user immediately.
     #>
+    [OutputType('Google.Apis.Gmail.v1.Data.VacationSettings')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Groups/Add-GSGroupMember.ps1
+++ b/PSGSuite/Public/Groups/Add-GSGroupMember.ps1
@@ -2,26 +2,27 @@ function Add-GSGroupMember {
     <#
     .SYNOPSIS
     Adds a list of emails to a target group
-    
+
     .DESCRIPTION
     Adds a list of emails to a target group. Designed for parity with Add-ADGroupMember
-    
+
     .PARAMETER Identity
     The email or GroupID of the target group to add members to
-    
+
     .PARAMETER Member
     The list of user and/or group emails that you would like to add to the target group
-    
+
     .PARAMETER Role
     The role that you would like to add the members as
-    
+
     Defaults to "MEMBER"
-    
+
     .EXAMPLE
     Add-GSGroupMember "admins@domain.com" -Member "joe-admin@domain.com","sally.admin@domain.com"
 
     Adds 2 users to the group "admins@domain.com"
     #>
+    [OutputType('Google.Apis.Admin.Directory.directory_v1.Data.Member')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Groups/Add-GSPrincipalGroupMembership.ps1
+++ b/PSGSuite/Public/Groups/Add-GSPrincipalGroupMembership.ps1
@@ -2,26 +2,27 @@ function Add-GSPrincipalGroupMembership {
     <#
     .SYNOPSIS
     Adds the target email to a list of groups
-    
+
     .DESCRIPTION
     Adds the target email to a list of groups. Designed for parity with Add-ADPrincipalGroupMembership
-    
+
     .PARAMETER Identity
     The user or group email that you would like to add to the list of groups
-    
+
     .PARAMETER MemberOf
     The list of groups to add the target email to
-    
+
     .PARAMETER Role
     The role that you would like to add the members as
-    
+
     Defaults to "MEMBER"
-    
+
     .EXAMPLE
     Add-GSPrincipalGroupMembership "joe@domain.com" -MemberOf "admins@domain.com","users@domain.com"
 
     Adds the email "joe@domain.com" to the admins@ and users@ groups
     #>
+    [OutputType('Google.Apis.Admin.Directory.directory_v1.Data.Member')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Groups/Get-GSGroup.ps1
+++ b/PSGSuite/Public/Groups/Get-GSGroup.ps1
@@ -46,6 +46,7 @@
 
     Gets the IT HelpDesk group by name using PowerShell syntax. PowerShell syntax is supported as a best effort, please refer to the Group Search documentation from Google for exact syntax.
     #>
+    [OutputType('Google.Apis.Admin.Directory.directory_v1.Data.Group')]
     [cmdletbinding(DefaultParameterSetName = "List")]
     Param
     (

--- a/PSGSuite/Public/Groups/Get-GSGroupAlias.ps1
+++ b/PSGSuite/Public/Groups/Get-GSGroupAlias.ps1
@@ -2,18 +2,19 @@ function Get-GSGroupAlias {
     <#
     .SYNOPSIS
     Gets the specified G SUite Group's aliases
-    
+
     .DESCRIPTION
     Gets the specified G SUite Group's aliases
-    
+
     .PARAMETER Group
     The primary email or ID of the group who you are trying to get aliases for. You can exclude the '@domain.com' to insert the Domain in the config or use the special 'me' to indicate the AdminEmail in the config.
-    
+
     .EXAMPLE
     Get-GSGroupAlias -Group hr
 
     Gets the list of aliases for the group hr@domain.com
     #>
+    [OutputType('Google.Apis.Admin.Directory.directory_v1.Data.Alias')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Groups/Get-GSGroupMember.ps1
+++ b/PSGSuite/Public/Groups/Get-GSGroupMember.ps1
@@ -23,6 +23,7 @@ function Get-GSGroupMember {
 
     Returns the list of owners and managers of the group "admins@domain.com"
     #>
+    [OutputType('Google.Apis.Admin.Directory.directory_v1.Data.Member')]
     [cmdletbinding(DefaultParameterSetName = "List")]
     Param (
         [parameter(Mandatory = $true,Position = 0,ValueFromPipeline = $true,ValueFromPipelineByPropertyName = $true)]

--- a/PSGSuite/Public/Groups/Get-GSGroupSettings.ps1
+++ b/PSGSuite/Public/Groups/Get-GSGroupSettings.ps1
@@ -2,20 +2,21 @@ function Get-GSGroupSettings {
     <#
     .SYNOPSIS
     Gets a group's settings
-    
+
     .DESCRIPTION
     Gets a group's settings
-    
+
     .PARAMETER Identity
     The email of the group
 
     If only the email name-part is passed, the full email will be contstructed using the Domain from the active config
-    
+
     .EXAMPLE
     Get-GSGroupSettings admins
 
     Gets the group settings for admins@domain.com
     #>
+    [OutputType('Google.Apis.Groupssettings.v1.Data.Groups')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Groups/New-GSGroup.ps1
+++ b/PSGSuite/Public/Groups/New-GSGroup.ps1
@@ -2,24 +2,25 @@ function New-GSGroup {
     <#
     .SYNOPSIS
     Creates a new Google Group
-    
+
     .DESCRIPTION
     Creates a new Google Group
-    
+
     .PARAMETER Email
     The desired email of the new group. If the group already exists, a GoogleApiException will be thrown. You can exclude the '@domain.com' to insert the Domain in the config
-    
+
     .PARAMETER Name
     The name of the new group
-    
+
     .PARAMETER Description
     The description of the new group
-    
+
     .EXAMPLE
     New-GSGroup -Email appdev -Name "Application Developers" -Description "App Dev team members"
 
     Creates a new group named "Application Developers" with the email "appdev@domain.com" and description "App Dev team members"
     #>
+    [OutputType('Google.Apis.Admin.Directory.directory_v1.Data.Group')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Groups/New-GSGroupAlias.ps1
+++ b/PSGSuite/Public/Groups/New-GSGroupAlias.ps1
@@ -2,21 +2,22 @@ function New-GSGroupAlias {
     <#
     .SYNOPSIS
     Creates a new alias for a G Suite group
-    
+
     .DESCRIPTION
     Creates a new alias for a G Suite group
-    
+
     .PARAMETER Group
     The group to create the alias for
-    
+
     .PARAMETER Alias
     The alias or list of aliases to create for the group
-    
+
     .EXAMPLE
     New-GSGroupAlias -Group humanresources@domain.com -Alias 'hr@domain.com','hrhelp@domain.com'
 
     Creates 2 new aliases for group Human Resources as 'hr@domain.com' and 'hrhelp@domain.com'
     #>
+    [OutputType('Google.Apis.Admin.Directory.directory_v1.Data.Alias')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Groups/Set-GSGroupSettings.ps1
+++ b/PSGSuite/Public/Groups/Set-GSGroupSettings.ps1
@@ -2,173 +2,174 @@ function Set-GSGroupSettings {
     <#
     .SYNOPSIS
     Hard-sets the settings for a group
-    
+
     .DESCRIPTION
     Hard-sets the settings for a group
-    
+
     .PARAMETER Identity
     The primary email or unique Id of the group to set
-    
+
     .PARAMETER Name
     The new name of the group
-    
+
     .PARAMETER Description
     The new description of the group
-    
+
     .PARAMETER ArchiveOnly
-    If the group is archive only 
-    
+    If the group is archive only
+
     .PARAMETER AllowExternalMembers
     Are external members allowed to join the group
-    
+
     .PARAMETER AllowGoogleCommunication
     Is google allowed to contact admins
-    
+
     .PARAMETER AllowWebPosting
     If posting from web is allowed
-    
+
     .PARAMETER CustomFooterText
     Custom footer text
-    
+
     .PARAMETER CustomReplyToAddress
     Default email to which reply to any message should go
-    
+
     .PARAMETER DefaultMessageDenyNotificationText
     Default message deny notification message
-    
+
     .PARAMETER Email
     Email id of the group
-    
+
     .PARAMETER IncludeCustomFooter
     Whether to include custom footer
-    
+
     .PARAMETER IncludeInGlobalAddressList
     If this groups should be included in global address list or not
-    
+
     .PARAMETER IsArchived
     If the contents of the group are archived
-    
+
     .PARAMETER MaxMessageBytes
     Maximum message size allowed
-    
+
     .PARAMETER MembersCanPostAsTheGroup
     Can members post using the group email address
-    
+
     .PARAMETER MessageDisplayFont
     Default message display font
-    
+
     Available values are:
     * "DEFAULT_FONT"
     * "FIXED_WIDTH_FONT"
-    
+
     .PARAMETER MessageModerationLevel
     Moderation level for messages
-    
-    Available values are: 
+
+    Available values are:
     * "MODERATE_ALL_MESSAGES"
     * "MODERATE_NON_MEMBERS"
     * "MODERATE_NEW_MEMBERS"
     * "MODERATE_NONE"
-    
+
     .PARAMETER ReplyTo
     Who should the default reply to a message go to
-    
-    Available values are: 
+
+    Available values are:
     * "REPLY_TO_CUSTOM"
     * "REPLY_TO_SENDER"
     * "REPLY_TO_LIST"
     * "REPLY_TO_OWNER"
     * "REPLY_TO_IGNORE"
     * "REPLY_TO_MANAGERS"
-    
+
     .PARAMETER SendMessageDenyNotification
     Should the member be notified if his message is denied by owner
-    
+
     .PARAMETER ShowInGroupDirectory
     Is the group listed in groups directory
-    
+
     .PARAMETER SpamModerationLevel
     Moderation level for messages detected as spam
-    
-    Available values are: 
-    * "ALLOW" 
-    * "MODERATE" 
-    * "SILENTLY_MODERATE" 
+
+    Available values are:
+    * "ALLOW"
+    * "MODERATE"
+    * "SILENTLY_MODERATE"
     * "REJECT"
-    
+
     .PARAMETER WhoCanAdd
     Permissions to add members
-    
-    Available values are: 
+
+    Available values are:
     * "ALL_MANAGERS_CAN_ADD"
     * "ALL_MEMBERS_CAN_ADD"
     * "NONE_CAN_ADD"
-    
+
     .PARAMETER WhoCanContactOwner
     Permission to contact owner of the group via web UI
-    
-    Available values are: 
-    * "ANYONE_CAN_CONTACT" 
-    * "ALL_IN_DOMAIN_CAN_CONTACT" 
-    * "ALL_MEMBERS_CAN_CONTACT" 
+
+    Available values are:
+    * "ANYONE_CAN_CONTACT"
+    * "ALL_IN_DOMAIN_CAN_CONTACT"
+    * "ALL_MEMBERS_CAN_CONTACT"
     * "ALL_MANAGERS_CAN_CONTACT"
-    
+
     .PARAMETER WhoCanInvite
-    Permissions to invite members. 
-    Available values are: 
-    * "ALL_MEMBERS_CAN_INVITE" 
-    * "ALL_MANAGERS_CAN_INVITE" 
+    Permissions to invite members.
+    Available values are:
+    * "ALL_MEMBERS_CAN_INVITE"
+    * "ALL_MANAGERS_CAN_INVITE"
     * "NONE_CAN_INVITE"
-    
+
     .PARAMETER WhoCanJoin
-    Permissions to join the group. 
-    Available values are: 
-    * "ANYONE_CAN_JOIN" 
-    * "ALL_IN_DOMAIN_CAN_JOIN" 
-    * "INVITED_CAN_JOIN" 
+    Permissions to join the group.
+    Available values are:
+    * "ANYONE_CAN_JOIN"
+    * "ALL_IN_DOMAIN_CAN_JOIN"
+    * "INVITED_CAN_JOIN"
     * "CAN_REQUEST_TO_JOIN"
-    
+
     .PARAMETER WhoCanLeaveGroup
     Permission to leave the group.
 
-    Available values are: 
-    * "ALL_MANAGERS_CAN_LEAVE" 
-    * "ALL_MEMBERS_CAN_LEAVE" 
+    Available values are:
+    * "ALL_MANAGERS_CAN_LEAVE"
+    * "ALL_MEMBERS_CAN_LEAVE"
     * "NONE_CAN_LEAVE"
-    
+
     .PARAMETER WhoCanPostMessage
-    Permissions to post messages to the group. 
-    
-    Available values are: 
-    * "NONE_CAN_POST" 
-    * "ALL_MANAGERS_CAN_POST" 
-    * "ALL_MEMBERS_CAN_POST" 
-    * "ALL_OWNERS_CAN_POST" 
-    * "ALL_IN_DOMAIN_CAN_POST" 
+    Permissions to post messages to the group.
+
+    Available values are:
+    * "NONE_CAN_POST"
+    * "ALL_MANAGERS_CAN_POST"
+    * "ALL_MEMBERS_CAN_POST"
+    * "ALL_OWNERS_CAN_POST"
+    * "ALL_IN_DOMAIN_CAN_POST"
     * "ANYONE_CAN_POST"
-    
+
     .PARAMETER WhoCanViewGroup
-    Permissions to view group. 
-    
-    Available values are: 
-    * "ANYONE_CAN_VIEW" 
-    * "ALL_IN_DOMAIN_CAN_VIEW" 
-    * "ALL_MEMBERS_CAN_VIEW" 
-    * "ALL_MANAGERS_CAN_VIEW" 
-    
+    Permissions to view group.
+
+    Available values are:
+    * "ANYONE_CAN_VIEW"
+    * "ALL_IN_DOMAIN_CAN_VIEW"
+    * "ALL_MEMBERS_CAN_VIEW"
+    * "ALL_MANAGERS_CAN_VIEW"
+
     .PARAMETER WhoCanViewMembership
-    Permissions to view membership. 
-    
-    Available values are: 
-    * "ALL_IN_DOMAIN_CAN_VIEW" 
-    * "ALL_MEMBERS_CAN_VIEW" 
-    * "ALL_MANAGERS_CAN_VIEW" 
-    
+    Permissions to view membership.
+
+    Available values are:
+    * "ALL_IN_DOMAIN_CAN_VIEW"
+    * "ALL_MEMBERS_CAN_VIEW"
+    * "ALL_MANAGERS_CAN_VIEW"
+
     .EXAMPLE
     Set-GSGroupSettings admins,hr-notifications -AllowExternalMembers:$false -WhoCanPostMessage ALL_OWNERS_CAN_POST
 
     Sets the group settings for both admins@domain.com and hr-notifications@domain.com to deny external members and limit posting to only group owners
     #>
+    [OutputType('Google.Apis.Groupssettings.v1.Data.Groups')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Groups/Update-GSGroupMember.ps1
+++ b/PSGSuite/Public/Groups/Update-GSGroupMember.ps1
@@ -35,6 +35,7 @@ function Update-GSGroupMember {
 
     Updates the delivery preference for all members of group 'myGroup@domain.com' to 'ALL_MAIL'
     #>
+    [OutputType('Google.Apis.Admin.Directory.directory_v1.Data.Member')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Groups/Update-GSGroupSettings.ps1
+++ b/PSGSuite/Public/Groups/Update-GSGroupSettings.ps1
@@ -2,173 +2,174 @@ function Update-GSGroupSettings {
     <#
     .SYNOPSIS
     Updates the settings for a group while retaining excluded, already existing settings
-    
+
     .DESCRIPTION
     Updates the settings for a group while retaining excluded, already existing settings
-    
+
     .PARAMETER Identity
     The primary email or unique Id of the group to update
-    
+
     .PARAMETER Name
     The new name of the group
-    
+
     .PARAMETER Description
     The new description of the group
-    
+
     .PARAMETER ArchiveOnly
-    If the group is archive only 
-    
+    If the group is archive only
+
     .PARAMETER AllowExternalMembers
     Are external members allowed to join the group
-    
+
     .PARAMETER AllowGoogleCommunication
     Is google allowed to contact admins
-    
+
     .PARAMETER AllowWebPosting
     If posting from web is allowed
-    
+
     .PARAMETER CustomFooterText
     Custom footer text
-    
+
     .PARAMETER CustomReplyToAddress
     Default email to which reply to any message should go
-    
+
     .PARAMETER DefaultMessageDenyNotificationText
     Default message deny notification message
-    
+
     .PARAMETER Email
     Email id of the group
-    
+
     .PARAMETER IncludeCustomFooter
     Whether to include custom footer
-    
+
     .PARAMETER IncludeInGlobalAddressList
     If this groups should be included in global address list or not
-    
+
     .PARAMETER IsArchived
     If the contents of the group are archived
-    
+
     .PARAMETER MaxMessageBytes
     Maximum message size allowed
-    
+
     .PARAMETER MembersCanPostAsTheGroup
     Can members post using the group email address
-    
+
     .PARAMETER MessageDisplayFont
     Default message display font
-    
+
     Available values are:
     * "DEFAULT_FONT"
     * "FIXED_WIDTH_FONT"
-    
+
     .PARAMETER MessageModerationLevel
     Moderation level for messages
-    
-    Available values are: 
+
+    Available values are:
     * "MODERATE_ALL_MESSAGES"
     * "MODERATE_NON_MEMBERS"
     * "MODERATE_NEW_MEMBERS"
     * "MODERATE_NONE"
-    
+
     .PARAMETER ReplyTo
     Who should the default reply to a message go to
-    
-    Available values are: 
+
+    Available values are:
     * "REPLY_TO_CUSTOM"
     * "REPLY_TO_SENDER"
     * "REPLY_TO_LIST"
     * "REPLY_TO_OWNER"
     * "REPLY_TO_IGNORE"
     * "REPLY_TO_MANAGERS"
-    
+
     .PARAMETER SendMessageDenyNotification
     Should the member be notified if his message is denied by owner
-    
+
     .PARAMETER ShowInGroupDirectory
     Is the group listed in groups directory
-    
+
     .PARAMETER SpamModerationLevel
     Moderation level for messages detected as spam
-    
-    Available values are: 
-    * "ALLOW" 
-    * "MODERATE" 
-    * "SILENTLY_MODERATE" 
+
+    Available values are:
+    * "ALLOW"
+    * "MODERATE"
+    * "SILENTLY_MODERATE"
     * "REJECT"
-    
+
     .PARAMETER WhoCanAdd
     Permissions to add members
-    
-    Available values are: 
+
+    Available values are:
     * "ALL_MANAGERS_CAN_ADD"
     * "ALL_MEMBERS_CAN_ADD"
     * "NONE_CAN_ADD"
-    
+
     .PARAMETER WhoCanContactOwner
     Permission to contact owner of the group via web UI
-    
-    Available values are: 
-    * "ANYONE_CAN_CONTACT" 
-    * "ALL_IN_DOMAIN_CAN_CONTACT" 
-    * "ALL_MEMBERS_CAN_CONTACT" 
+
+    Available values are:
+    * "ANYONE_CAN_CONTACT"
+    * "ALL_IN_DOMAIN_CAN_CONTACT"
+    * "ALL_MEMBERS_CAN_CONTACT"
     * "ALL_MANAGERS_CAN_CONTACT"
-    
+
     .PARAMETER WhoCanInvite
-    Permissions to invite members. 
-    Available values are: 
-    * "ALL_MEMBERS_CAN_INVITE" 
-    * "ALL_MANAGERS_CAN_INVITE" 
+    Permissions to invite members.
+    Available values are:
+    * "ALL_MEMBERS_CAN_INVITE"
+    * "ALL_MANAGERS_CAN_INVITE"
     * "NONE_CAN_INVITE"
-    
+
     .PARAMETER WhoCanJoin
-    Permissions to join the group. 
-    Available values are: 
-    * "ANYONE_CAN_JOIN" 
-    * "ALL_IN_DOMAIN_CAN_JOIN" 
-    * "INVITED_CAN_JOIN" 
+    Permissions to join the group.
+    Available values are:
+    * "ANYONE_CAN_JOIN"
+    * "ALL_IN_DOMAIN_CAN_JOIN"
+    * "INVITED_CAN_JOIN"
     * "CAN_REQUEST_TO_JOIN"
-    
+
     .PARAMETER WhoCanLeaveGroup
     Permission to leave the group.
 
-    Available values are: 
-    * "ALL_MANAGERS_CAN_LEAVE" 
-    * "ALL_MEMBERS_CAN_LEAVE" 
+    Available values are:
+    * "ALL_MANAGERS_CAN_LEAVE"
+    * "ALL_MEMBERS_CAN_LEAVE"
     * "NONE_CAN_LEAVE"
-    
+
     .PARAMETER WhoCanPostMessage
-    Permissions to post messages to the group. 
-    
-    Available values are: 
-    * "NONE_CAN_POST" 
-    * "ALL_MANAGERS_CAN_POST" 
-    * "ALL_MEMBERS_CAN_POST" 
-    * "ALL_OWNERS_CAN_POST" 
-    * "ALL_IN_DOMAIN_CAN_POST" 
+    Permissions to post messages to the group.
+
+    Available values are:
+    * "NONE_CAN_POST"
+    * "ALL_MANAGERS_CAN_POST"
+    * "ALL_MEMBERS_CAN_POST"
+    * "ALL_OWNERS_CAN_POST"
+    * "ALL_IN_DOMAIN_CAN_POST"
     * "ANYONE_CAN_POST"
-    
+
     .PARAMETER WhoCanViewGroup
-    Permissions to view group. 
-    
-    Available values are: 
-    * "ANYONE_CAN_VIEW" 
-    * "ALL_IN_DOMAIN_CAN_VIEW" 
-    * "ALL_MEMBERS_CAN_VIEW" 
-    * "ALL_MANAGERS_CAN_VIEW" 
-    
+    Permissions to view group.
+
+    Available values are:
+    * "ANYONE_CAN_VIEW"
+    * "ALL_IN_DOMAIN_CAN_VIEW"
+    * "ALL_MEMBERS_CAN_VIEW"
+    * "ALL_MANAGERS_CAN_VIEW"
+
     .PARAMETER WhoCanViewMembership
-    Permissions to view membership. 
-    
-    Available values are: 
-    * "ALL_IN_DOMAIN_CAN_VIEW" 
-    * "ALL_MEMBERS_CAN_VIEW" 
-    * "ALL_MANAGERS_CAN_VIEW" 
-    
+    Permissions to view membership.
+
+    Available values are:
+    * "ALL_IN_DOMAIN_CAN_VIEW"
+    * "ALL_MEMBERS_CAN_VIEW"
+    * "ALL_MANAGERS_CAN_VIEW"
+
     .EXAMPLE
     Updates-GSGroupSettings admins,hr-notifications -AllowExternalMembers:$false -WhoCanPostMessage ALL_OWNERS_CAN_POST
 
     Updates the group settings for both admins@domain.com and hr-notifications@domain.com to deny external members and limit posting to only group owners
     #>
+    [OutputType('Google.Apis.Groupssettings.v1.Data.Groups')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Licensing/Get-GSUserLicense.ps1
+++ b/PSGSuite/Public/Licensing/Get-GSUserLicense.ps1
@@ -2,27 +2,28 @@ function Get-GSUserLicense {
     <#
     .SYNOPSIS
     Gets the G Suite license information for a user or list of users
-    
+
     .DESCRIPTION
     Gets the G Suite license information for a user or list of users
-    
+
     .PARAMETER User
-    The primary email or unique Id of the user to retrieve license information for 
-    
+    The primary email or unique Id of the user to retrieve license information for
+
     .PARAMETER License
     The license SKU to retrieve information for. If excluded, searches all license SKUs
-    
+
     .PARAMETER ProductID
     The product Id to list licenses for
-    
+
     .PARAMETER PageSize
     The page size of the result set
-    
+
     .EXAMPLE
     Get-GSUserLicense
 
     Gets the full list of licenses for the customer
     #>
+    [OutputType('Google.Apis.Licensing.v1.Data.LicenseAssignment')]
     [cmdletbinding(DefaultParameterSetName = "List")]
     Param
     (
@@ -103,7 +104,7 @@ function Get-GSUserLicense {
                                     $request = $service.LicenseAssignments.Get($productHash[$License],$License,$U)
                                     $response = $request.Execute()
                                 }
-                                catch { 
+                                catch {
                                 }
                                 if ($response) {
                                     break

--- a/PSGSuite/Public/Licensing/Set-GSUserLicense.ps1
+++ b/PSGSuite/Public/Licensing/Set-GSUserLicense.ps1
@@ -2,21 +2,22 @@ function Set-GSUserLicense {
     <#
     .SYNOPSIS
     Sets the license for a user
-    
+
     .DESCRIPTION
     Sets the license for a user
-    
+
     .PARAMETER User
     The user's current primary email address
-    
+
     .PARAMETER License
     The license SKU to set for the user
-    
+
     .EXAMPLE
     Set-GSUserLicense -User joe -License Google-Apps-For-Business
 
     Sets Joe to a Google-Apps-For-Business license
     #>
+    [OutputType('Google.Apis.Licensing.v1.Data.LicenseAssignment')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Licensing/Update-GSUserLicense.ps1
+++ b/PSGSuite/Public/Licensing/Update-GSUserLicense.ps1
@@ -2,21 +2,22 @@ function Update-GSUserLicense {
     <#
     .SYNOPSIS
     Reassign a user's product SKU with a different SKU in the same product
-    
+
     .DESCRIPTION
     Reassign a user's product SKU with a different SKU in the same product
-    
+
     .PARAMETER User
     The user's current primary email address
-    
+
     .PARAMETER License
     The license SKU that you would like to reassign the user to
-    
+
     .EXAMPLE
     Update-GSUserLicense -User joe -License G-Suite-Enterprise
 
     Updates Joe to a G-Suite-Enterprise license
     #>
+    [OutputType('Google.Apis.Licensing.v1.Data.LicenseAssignment')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Org Units/Get-GSOrganizationalUnit.ps1
+++ b/PSGSuite/Public/Org Units/Get-GSOrganizationalUnit.ps1
@@ -2,13 +2,13 @@ function Get-GSOrganizationalUnit {
     <#
     .SYNOPSIS
     Gets Organizational Unit information
-    
+
     .DESCRIPTION
     Gets Organizational Unit information
-    
+
     .PARAMETER SearchBase
     The OrgUnitPath you would like to search for. This can be the single OrgUnit to return or the top level of which to return children of
-    
+
     .PARAMETER SearchScope
     The depth at which to return the list of OrgUnits children
 
@@ -20,12 +20,13 @@ function Get-GSOrganizationalUnit {
     * "Children": same as OneLevel
 
     Defaults to 'All'
-    
+
     .EXAMPLE
     Get-GSOrganizationalUnit -SearchBase "/" -SearchScope Base
 
     Gets the top level Organizational Unit information
     #>
+    [OutputType('Google.Apis.Admin.Directory.directory_v1.Data.OrgUnit')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Org Units/New-GSOrganizationalUnit.ps1
+++ b/PSGSuite/Public/Org Units/New-GSOrganizationalUnit.ps1
@@ -2,32 +2,33 @@ function New-GSOrganizationalUnit {
     <#
     .SYNOPSIS
     Creates a new OrgUnit
-    
+
     .DESCRIPTION
     Creates a new Organizational Unit
-    
+
     .PARAMETER Name
     The name of the new OrgUnit
-    
+
     .PARAMETER ParentOrgUnitPath
     The path of the parent OrgUnit
 
     Defaults to "/" (the root OrgUnit)
 
     .PARAMETER ParentOrgUnitId
-    The unique ID of the parent organizational unit. 
-    
+    The unique ID of the parent organizational unit.
+
     .PARAMETER Description
     Description of the organizational unit.
-    
+
     .PARAMETER BlockInheritance
     Determines if a sub-organizational unit can inherit the settings of the parent organization. The default value is false, meaning a sub-organizational unit inherits the settings of the nearest parent organizational unit. For more information on inheritance and users in an organization structure, see the administration help center: http://support.google.com/a/bin/answer.py?hl=en&answer=182442&topic=1227584&ctx=topic
-    
+
     .EXAMPLE
     New-GSOrganizationalUnit -Name "Test Org" -ParentOrgUnitPath "/Testing" -Description "This is a test OrgUnit"
-    
+
     Creates a new OrgUnit named "Test Org" underneath the existing org unit path "/Testing" with the description "This is a test OrgUnit"
     #>
+    [OutputType('Google.Apis.Admin.Directory.directory_v1.Data.OrgUnit')]
     [cmdletbinding(DefaultParameterSetName = 'ParentOrgUnitPath')]
     Param
     (

--- a/PSGSuite/Public/Org Units/Update-GSOrganizationalUnit.ps1
+++ b/PSGSuite/Public/Org Units/Update-GSOrganizationalUnit.ps1
@@ -2,36 +2,37 @@
     <#
     .SYNOPSIS
     Updates an OrgUnit
-    
+
     .DESCRIPTION
     Updates an Organizational Unit
-    
+
     .PARAMETER OrgUnitID
     The unique Id of the OrgUnit to update
-    
+
     .PARAMETER OrgUnitPath
     The path of the OrgUnit to update
-    
+
     .PARAMETER Name
     The new name for the OrgUnit
-    
+
     .PARAMETER ParentOrgUnitId
     The new Parent ID for the OrgUnit
-    
+
     .PARAMETER ParentOrgUnitPath
     The path of the new Parent for the OrgUnit
-    
+
     .PARAMETER Description
     The new description for the OrgUnit
-    
+
     .PARAMETER BlockInheritance
     Determines if a sub-organizational unit can inherit the settings of the parent organization. The default value is false, meaning a sub-organizational unit inherits the settings of the nearest parent organizational unit. For more information on inheritance and users in an organization structure, see the administration help center: http://support.google.com/a/bin/answer.py?hl=en&answer=182442&topic=1227584&ctx=topic
-    
+
     .EXAMPLE
     Update-GSOrganizationalUnit -OrgUnitPath "/Testing" -Name "Testing More" -Description "Doing some more testing"
 
     Updates the OrgUnit '/Testing' with a new name "Testing More" and new description "Doing some more testing"
     #>
+    [OutputType('Google.Apis.Admin.Directory.directory_v1.Data.OrgUnit')]
     [cmdletbinding(DefaultParameterSetName = "Id")]
     Param
     (

--- a/PSGSuite/Public/Reports/Get-GSActivityReport.ps1
+++ b/PSGSuite/Public/Reports/Get-GSActivityReport.ps1
@@ -2,16 +2,16 @@ function Get-GSActivityReport {
     <#
     .SYNOPSIS
     Retrieves a list of activities
-    
+
     .DESCRIPTION
     Retrieves a list of activities
-    
+
     .PARAMETER UserKey
     Represents the profile id or the user email for which the data should be filtered. When 'all' is specified as the userKey, it returns usageReports for all users
-    
+
     .PARAMETER ApplicationName
-    Application name for which the events are to be retrieved. 
-    
+    Application name for which the events are to be retrieved.
+
     Available values are:
     * "Admin": The Admin console application's activity reports return account information about different types of administrator activity events.
     * "Calendar": The G Suite Calendar application's activity reports return information about various Calendar activity events.
@@ -24,27 +24,28 @@ function Get-GSActivityReport {
     * "Token": The G Suite Token application's activity reports return account information about different types of Token activity events.
 
     Defaults to "Admin"
-    
+
     .PARAMETER EventName
     The name of the event being queried
-    
+
     .PARAMETER ActorIpAddress
     IP Address of host where the event was performed. Supports both IPv4 and IPv6 addresses
-    
+
     .PARAMETER EndTime
     Return events which occurred at or before this time
-    
+
     .PARAMETER Filters
     Event parameters in the form [parameter1 name][operator][parameter1 value]
-    
+
     .PARAMETER PageSize
     Number of activity records to be shown in each page
-    
+
     .EXAMPLE
     Get-GSActivityReport -StartTime (Get-Date).AddDays(-30)
 
     Gets the admin activity report for the last 30 days
     #>
+    [OutputType('Google.Apis.Admin.Reports.reports_v1.Data.Activity')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/RoleAssignments/Get-GSAdminRoleAssignment.ps1
+++ b/PSGSuite/Public/RoleAssignments/Get-GSAdminRoleAssignment.ps1
@@ -2,38 +2,39 @@ function Get-GSAdminRoleAssignment {
     <#
     .SYNOPSIS
     Gets a specific Admin Role Assignments or the list of Admin Role Assignments for a given role
-    
+
     .DESCRIPTION
     Gets a specific Admin Role Assignments or the list of Admin Role Assignments for a given role
-    
+
     .PARAMETER RoleAssignmentId
     The RoleAssignmentId(s) you would like to retrieve info for.
 
     If left blank, returns the full list of Role Assignments
-    
+
     .PARAMETER UserKey
     The UserKey(s) you would like to retrieve Role Assignments for. This can be a user's email or their unique UserId
 
     If left blank, returns the full list of Role Assignments
-    
+
     .PARAMETER RoleId
     The RoleId(s) you would like to retrieve Role Assignments for.
 
     If left blank, returns the full list of Role Assignments
-    
+
     .PARAMETER PageSize
     Page size of the result set
-    
+
     .EXAMPLE
     Get-GSAdminRoleAssignment
 
     Gets the list of Admin Role Assignments
-    
+
     .EXAMPLE
     Get-GSAdminRoleAssignment -RoleId 9191482342768644,9191482342768642
 
     Gets the Admin Role Assignments matching the provided RoleIds
     #>
+    [OutputType('Google.Apis.Admin.Directory.directory_v1.Data.RoleAssignment')]
     [cmdletbinding(DefaultParameterSetName = "ListUserKey")]
     Param
     (
@@ -138,7 +139,7 @@ function Get-GSAdminRoleAssignment {
                                     $request.UserKey = $uKey
                                     do {
                                         $result = $request.Execute()
-                                        $result.Items | Add-Member -MemberType NoteProperty -Name 'Filter' -Value ([PSCustomObject]@{UserKey = $User}) -PassThru 
+                                        $result.Items | Add-Member -MemberType NoteProperty -Name 'Filter' -Value ([PSCustomObject]@{UserKey = $User}) -PassThru
                                         $request.PageToken = $result.NextPageToken
                                         [int]$retrieved = ($i + $result.Items.Count) - 1
                                         Write-Verbose "Retrieved $retrieved role assignments..."

--- a/PSGSuite/Public/RoleAssignments/New-GSAdminRoleAssignment.ps1
+++ b/PSGSuite/Public/RoleAssignments/New-GSAdminRoleAssignment.ps1
@@ -27,6 +27,7 @@ function New-GSAdminRoleAssignment {
 
     Assign a new role to a given user.
     #>
+    [OutputType('Google.Apis.Admin.Directory.directory_v1.Data.RoleAssignment')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Roles/Get-GSAdminRole.ps1
+++ b/PSGSuite/Public/Roles/Get-GSAdminRole.ps1
@@ -2,28 +2,29 @@ function Get-GSAdminRole {
     <#
     .SYNOPSIS
     Gets a specific Admin Role or the list of Admin Roles
-    
+
     .DESCRIPTION
     Gets a specific Admin Role or the list of Admin Roles
-    
+
     .PARAMETER RoleId
     The RoleId(s) you would like to retrieve info for.
 
     If left blank, returns the full list of Roles
-    
+
     .PARAMETER PageSize
     Page size of the result set
-    
+
     .EXAMPLE
     Get-GSAdminRole
 
     Gets the list of Admin Roles
-    
+
     .EXAMPLE
     Get-GSAdminRole -RoleId 9191482342768644,9191482342768642
 
     Gets the admin roles matching the provided Ids
     #>
+    [OutputType('Google.Apis.Admin.Directory.directory_v1.Data.Role')]
     [cmdletbinding(DefaultParameterSetName = "List")]
     Param
     (

--- a/PSGSuite/Public/Roles/New-GSAdminRole.ps1
+++ b/PSGSuite/Public/Roles/New-GSAdminRole.ps1
@@ -2,29 +2,30 @@ function New-GSAdminRole {
     <#
     .SYNOPSIS
     Creates a new Admin Role
-    
+
     .DESCRIPTION
     Creates a new Admin Role
-    
+
     .PARAMETER RoleName
     The name of the new role
-    
+
     .PARAMETER RolePrivileges
     The set of privileges that are granted to this role.
 
     .PARAMETER RoleDescription
     A short description of the role.
-    
+
     .EXAMPLE
     Get-GSAdminRole
 
     Gets the list of Admin Roles
-    
+
     .EXAMPLE
     Get-GSAdminRole -RoleId '9191482342768644','9191482342768642'
 
     Gets the admin roles matching the provided Ids
     #>
+    [OutputType('Google.Apis.Admin.Directory.directory_v1.Data.Role')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Roles/Update-GSAdminRole.ps1
+++ b/PSGSuite/Public/Roles/Update-GSAdminRole.ps1
@@ -2,36 +2,37 @@ function Update-GSAdminRole {
     <#
     .SYNOPSIS
     Update an Admin Role
-    
+
     .DESCRIPTION
     Update an Admin Role
 
     .PARAMETER RoleId
     The Id of the role to update
-    
+
     .PARAMETER RoleName
     The name of the role
-    
+
     .PARAMETER RolePrivileges
     The set of privileges that are granted to this role.
 
     .PARAMETER RoleDescription
     A short description of the role.
-    
+
     .EXAMPLE
     Update-GSAdminRole -RoleId 9191482342768644 -RoleName 'Help_Desk_Level2' -RoleDescription 'Help Desk Level 2'
 
     Updates the specified Admin Role with a new name and description
-    
+
     .EXAMPLE
     Get-GSAdminRole | Where-Object {$_.RoleDescription -like "*Help*Desk*"} | Update-GSAdminRole -RoleId 9191482342768644 -RoleName 'Help_Desk_Level2' -RoleDescription 'Help Desk Level 2'
 
     Updates the specified Admin Role's RolePrivileges to match every other Admin Role with Help Desk in the description. Useful for basing a new role off another to add additional permissions on there
     #>
+    [OutputType('Google.Apis.Admin.Directory.directory_v1.Data.Role')]
     [cmdletbinding()]
     Param
     (
-        
+
         [parameter(Mandatory = $true,Position = 0)]
         [int64]
         $RoleId,

--- a/PSGSuite/Public/Schemas/Get-GSUserSchema.ps1
+++ b/PSGSuite/Public/Schemas/Get-GSUserSchema.ps1
@@ -2,18 +2,19 @@ function Get-GSUserSchema {
     <#
     .SYNOPSIS
     Gets custom user schema info
-    
+
     .DESCRIPTION
     Gets custom user schema info
-    
+
     .PARAMETER SchemaId
     The Id or Name of the user schema you would like to return info for. If excluded, gets the full list of user schemas
-    
+
     .EXAMPLE
     Get-GSUserSchema
 
     Gets the list of custom user schemas
     #>
+    [OutputType('Google.Apis.Admin.Directory.directory_v1.Data.Schema')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Schemas/New-GSUserSchema.ps1
+++ b/PSGSuite/Public/Schemas/New-GSUserSchema.ps1
@@ -2,23 +2,24 @@ function New-GSUserSchema {
     <#
     .SYNOPSIS
     Creates a new user schema
-    
+
     .DESCRIPTION
     Creates a new user schema
-    
+
     .PARAMETER SchemaName
     The name of the schema to create
-    
+
     .PARAMETER Fields
     New schema fields to set
-    
+
     Expects SchemaFieldSpec objects. You can create these with the helper function Add-GSUserSchemaField, i.e.: Add-GSUserSchemaField -FieldName "date" -FieldType DATE -ReadAccessType ADMINS_AND_SELF
-    
+
     .EXAMPLE
     New-GSUserSchema -SchemaName "SDK" -Fields (Add-GSUserSchemaField -FieldName "string" -FieldType STRING -ReadAccessType ADMINS_AND_SELF),(Add-GSUserSchemaField -FieldName "date" -FieldType DATE -ReadAccessType ADMINS_AND_SELF)
 
     This command will create a schema named "SDK" with two fields, "string" and "date", readable by ADMINS_AND_SELF
     #>
+    [OutputType('Google.Apis.Admin.Directory.directory_v1.Data.Schema')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Schemas/Set-GSUserSchema.ps1
+++ b/PSGSuite/Public/Schemas/Set-GSUserSchema.ps1
@@ -2,26 +2,27 @@ function Set-GSUserSchema {
     <#
     .SYNOPSIS
     Hard-sets a schema's configuration
-    
+
     .DESCRIPTION
     Hard-sets a schema's configuration
-    
+
     .PARAMETER SchemaId
     The unique Id of the schema to set
-    
+
     .PARAMETER SchemaName
     The new schema name
-    
+
     .PARAMETER Fields
     New schema fields to set
 
     Expects SchemaFieldSpec objects. You can create these with the helper function Add-GSUserSchemaField, i.e.: Add-GSUserSchemaField -FieldName "date" -FieldType DATE -ReadAccessType ADMINS_AND_SELF
-    
+
     .EXAMPLE
     Set-GSUserSchema -SchemaId "9804800jfl08917304j" -SchemaName "SDK_2" -Fields (Add-GSUserSchemaField -FieldName "string2" -FieldType STRING -ReadAccessType ADMINS_AND_SELF)
 
     This command will set the schema Id '9804800jfl08917304j' with the name "SDK_2" and one field "string2" readable by ADMINS_AND_SELF
     #>
+    [OutputType('Google.Apis.Admin.Directory.directory_v1.Data.Schema')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Schemas/Update-GSUserSchema.ps1
+++ b/PSGSuite/Public/Schemas/Update-GSUserSchema.ps1
@@ -2,26 +2,27 @@ function Update-GSUserSchema {
     <#
     .SYNOPSIS
     Updates/patches a schema's configuration
-    
+
     .DESCRIPTION
     Updates/patches a schema's configuration
-    
+
     .PARAMETER SchemaId
     The unique Id of the schema to update
-    
+
     .PARAMETER SchemaName
     The new schema name
-    
+
     .PARAMETER Fields
     New schema fields to set
 
     Expects SchemaFieldSpec objects. You can create these with the helper function Add-GSUserSchemaField, i.e.: Add-GSUserSchemaField -FieldName "date" -FieldType DATE -ReadAccessType ADMINS_AND_SELF
-    
+
     .EXAMPLE
     Update-GSUserSchema -SchemaId "9804800jfl08917304j" -SchemaName "SDK_2" -Fields (Add-GSUserSchemaField -FieldName "string2" -FieldType STRING -ReadAccessType ADMINS_AND_SELF)
 
     This command will update the schema Id '9804800jfl08917304j' with the name "SDK_2" and add one field "string2" readable by ADMINS_AND_SELF
     #>
+    [OutputType('Google.Apis.Admin.Directory.directory_v1.Data.Schema')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Security/Get-GSMobileDevice.ps1
+++ b/PSGSuite/Public/Security/Get-GSMobileDevice.ps1
@@ -2,16 +2,16 @@
     <#
     .SYNOPSIS
     Gets the list of Mobile Devices registered for the user's account
-    
+
     .DESCRIPTION
     Gets the list of Mobile Devices registered for the user's account
-    
+
     .PARAMETER User
     The user that you would like to retrieve the Mobile Device list for. If no user is specified, it will list all of the Mobile Devices of the CustomerID
-    
+
     .PARAMETER Filter
     Search string in the format given at: http://support.google.com/a/bin/answer.py?hl=en&answer=1408863#search
-    
+
     .PARAMETER Projection
     Restrict information returned to a set of selected fields.
 
@@ -20,12 +20,12 @@
     * "FULL": Includes all metadata fields
 
     Defauls to "FULL"
-    
+
     .PARAMETER PageSize
     Page size of the result set
-    
+
     .PARAMETER OrderBy
-    Device property to use for sorting results. 
+    Device property to use for sorting results.
 
     Acceptable values are:
     * "deviceId": The serial number for a Google Sync mobile device. For Android devices, this is a software generated unique identifier.
@@ -36,19 +36,20 @@
     * "os": The device's operating system.
     * "status": The device status.
     * "type": Type of the device.
-    
+
     .PARAMETER SortOrder
     Whether to return results in ascending or descending order. Must be used with the OrderBy parameter.
 
     Acceptable values are:
     * "ASCENDING": Ascending order.
     * "DESCENDING": Descending order.
-    
+
     .EXAMPLE
     Get-GSMobileDevice
 
     Gets the Mobile Device list for the AdminEmail
     #>
+    [OutputType('Google.Apis.Admin.Directory.directory_v1.Data.MobileDevice')]
     [cmdletbinding(DefaultParameterSetName = "User")]
     Param
     (

--- a/PSGSuite/Public/Security/Get-GSUserASP.ps1
+++ b/PSGSuite/Public/Security/Get-GSUserASP.ps1
@@ -2,23 +2,24 @@
     <#
     .SYNOPSIS
     Gets Application Specific Passwords for a user
-    
+
     .DESCRIPTION
     Gets Application Specific Passwords for a user
-    
+
     .PARAMETER User
     The primary email or UserID of the user who you are trying to get info for. You can exclude the '@domain.com' to insert the Domain in the config or use the special 'me' to indicate the AdminEmail in the config.
 
     Defaults to the AdminEmail in the config
-    
+
     .PARAMETER CodeId
     The ID of the ASP you would like info for. If excluded, returns the full list of ASP's for the user
-    
+
     .EXAMPLE
     Get-GSUserASP
 
     Gets the list of Application Specific Passwords for the user
     #>
+    [OutputType('Google.Apis.Admin.Directory.directory_v1.Data.Asp')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Security/Get-GSUserToken.ps1
+++ b/PSGSuite/Public/Security/Get-GSUserToken.ps1
@@ -2,23 +2,24 @@
     <#
     .SYNOPSIS
     Gets security tokens for a user
-    
+
     .DESCRIPTION
     Gets security tokens for a user
-    
+
     .PARAMETER User
     The primary email or UserID of the user who you are trying to get info for. You can exclude the '@domain.com' to insert the Domain in the config or use the special 'me' to indicate the AdminEmail in the config.
 
     Defaults to the AdminEmail in the config
-    
+
     .PARAMETER ClientId
     The Id of the client you are trying to get token info for. If excluded, gets the full list of tokens for the user
-    
+
     .EXAMPLE
     Get-GSUserToken -ClientId "Google Chrome"
 
     Gets the token info for "Google Chrome" for the AdminEmail user
     #>
+    [OutputType('Google.Apis.Admin.Directory.directory_v1.Data.Token')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Security/Get-GSUserVerificationCodes.ps1
+++ b/PSGSuite/Public/Security/Get-GSUserVerificationCodes.ps1
@@ -2,20 +2,21 @@
     <#
     .SYNOPSIS
     Gets the 2-Step Verification Codes for the user
-    
+
     .DESCRIPTION
     Gets the 2-Step Verification Codes for the user
-    
+
     .PARAMETER User
     The primary email or UserID of the user who you are trying to get info for. You can exclude the '@domain.com' to insert the Domain in the config or use the special 'me' to indicate the AdminEmail in the config.
 
     Defaults to the AdminEmail in the config
-    
+
     .EXAMPLE
     Get-GSUserVerificationCodes
 
     Gets the Verification Codes for AdminEmail user
     #>
+    [OutputType('Google.Apis.Admin.Directory.directory_v1.Data.VerificationCode')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Security/New-GSUserVerificationCodes.ps1
+++ b/PSGSuite/Public/Security/New-GSUserVerificationCodes.ps1
@@ -2,18 +2,19 @@
     <#
     .SYNOPSIS
     Generates new verification codes for the user
-    
+
     .DESCRIPTION
     Generates new verification codes for the user
-    
+
     .PARAMETER User
     The primary email or UserID of the user who you are trying to get info for. You can exclude the '@domain.com' to insert the Domain in the config or use the special 'me' to indicate the AdminEmail in the config
-    
+
     .EXAMPLE
     New-GSUserVerificationCodes -User me
 
     Generates new verification codes for the AdminEmail user
     #>
+    [OutputType('Google.Apis.Admin.Directory.directory_v1.Data.VerificationCode')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Security/Update-GSMobileDevice.ps1
+++ b/PSGSuite/Public/Security/Update-GSMobileDevice.ps1
@@ -25,6 +25,7 @@ function Update-GSMobileDevice {
 
     Approves the mobile device with the specified Id
     #>
+    [OutputType('Google.Apis.Admin.Directory.directory_v1.Data.MobileDevice')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Sheets/Clear-GSSheet.ps1
+++ b/PSGSuite/Public/Sheets/Clear-GSSheet.ps1
@@ -2,33 +2,34 @@ function Clear-GSSheet {
     <#
     .SYNOPSIS
     Clears a Sheet
-    
+
     .DESCRIPTION
     Clears a Sheet
-    
+
     .PARAMETER SpreadsheetId
     The unique Id of the SpreadSheet
-    
+
     .PARAMETER SheetName
     The name of the Sheet (tab) to clear
-    
+
     .PARAMETER Range
     The specific range to clear. If excluded, clears the entire Sheet
-    
+
     .PARAMETER User
     The primary email of the user who has Edit rights to the target Range/Sheet
-    
+
     .PARAMETER Raw
     If $true, return the raw response, otherwise, return a flattened response for readability
-    
+
     .EXAMPLE
     Clear-GSSheet -SpreadsheetId '1ZVdewVhy-VtVLyGL1lk2kgvySIF_bCfJA6ggn7obGh2U' -SheetName 2017
 
     Clears the Sheet '2017' located on the SpreadSheet Id provided
     #>
+    [OutputType('Google.Apis.Sheets.v4.Data.Spreadsheet')]
     [cmdletbinding()]
     Param
-    (      
+    (
         [parameter(Mandatory = $true,Position = 0)]
         [String]
         $SpreadsheetId,

--- a/PSGSuite/Public/Sheets/Copy-GSSheet.ps1
+++ b/PSGSuite/Public/Sheets/Copy-GSSheet.ps1
@@ -2,28 +2,28 @@ function Copy-GSSheet {
     <#
     .SYNOPSIS
     Copies a Sheet from one SpreadSheet to another
-    
+
     .DESCRIPTION
     Copies a Sheet from one SpreadSheet to another
-    
+
     .PARAMETER SourceSpreadsheetId
     The unique Id of the SpreadSheet to copy the Sheet from
-    
+
     .PARAMETER SourceSheetId
     The Id of the Sheet to copy
-    
+
     .PARAMETER DestinationSpreadsheetId
     The target SpreadSheet to copy the Sheet to
-    
+
     .PARAMETER NewSheetTitle
     The new title for the new SpreadhSheet to create if not copying to a Destination Sheet
-    
+
     .PARAMETER User
     The primary email of the user who has at least Edit rights to both the Source SpreadSheet and Destination SpreadSheet
-    
+
     .PARAMETER Raw
     If $true, return the raw response, otherwise, return a flattened response for readability
-    
+
     .EXAMPLE
     Copy-GSSheet -SourceSpreadsheetId '1ZVdewVhy-VtVLyGLhClkj8234ljk_fJA6ggn7obGh2U' -SourceSheetId 2017 -NewSheetTitle '2017 Archive'
 
@@ -31,7 +31,7 @@ function Copy-GSSheet {
     #>
     [cmdletbinding(DefaultParameterSetName = "CreateNewSheet")]
     Param
-    (      
+    (
         [parameter(Mandatory = $true,Position = 0)]
         [String]
         $SourceSpreadsheetId,

--- a/PSGSuite/Public/Sheets/Export-GSSheet.ps1
+++ b/PSGSuite/Public/Sheets/Export-GSSheet.ps1
@@ -2,62 +2,63 @@ function Export-GSSheet {
     <#
     .SYNOPSIS
     Updates a Sheet's values
-    
+
     .DESCRIPTION
     Updates a Sheet's values. Accepts either an Array of objects/strings/ints or a single value
-    
+
     .PARAMETER SpreadsheetId
     The unique Id of the SpreadSheet to update if updating an existing Sheet
-    
+
     .PARAMETER NewSheetTitle
     The title of the new SpreadSheet to be created
-    
+
     .PARAMETER Array
     Array of objects/strings/ints to add to the SpreadSheet
-    
+
     .PARAMETER Value
     A single value to update 1 cell with. Useful if you are tracking the last time updated in a specific cell during a job that updates Sheets
-    
+
     .PARAMETER SheetName
     The name of the Sheet to add the data to. If excluded, defaults to Sheet Id '0'. If a new SpreadSheet is being created, this is set to 'Sheet1' to prevent error
-    
+
     .PARAMETER Style
     The table style you would like to export the data as
 
     Available values are:
     * "Standard": headers are on Row 1, table rows are added as subsequent rows (Default)
     * "Horizontal": headers are on Column A, table rows are added as subsequent columns
-    
+
     .PARAMETER Range
     The specific range to add the value(s) to. If using the -Value parameter, set this to the specific cell you would like to set the value of
-    
+
     .PARAMETER Append
     If $true, skips adding headers to the Sheet
-    
+
     .PARAMETER User
     The primary email of the user that had at least Edit rights to the target Sheet
 
     Defaults to the AdminEmail user
-    
+
     .PARAMETER ValueInputOption
     How the input data should be interpreted
 
-    Available values are: 
+    Available values are:
     * "INPUT_VALUE_OPTION_UNSPECIFIED"
     * "RAW"
     * "USER_ENTERED"
-    
+
     .PARAMETER IncludeValuesInResponse
     Determines if the update response should include the values of the cells that were updated. By default, responses do not include the updated values
-    
+
     .PARAMETER Launch
     If $true, opens the new SpreadSheet Url in your default browser
-    
+
     .EXAMPLE
     $array | Export-GSSheet -NewSheetTitle "Finance Workbook" -Launch
 
 
     #>
+    [OutputType('Google.Apis.Sheets.v4.Data.Spreadsheet')]
     [cmdletbinding(DefaultParameterSetName = "CreateNewSheetArray")]
     Param
     (

--- a/PSGSuite/Public/Sheets/Get-GSSheetInfo.ps1
+++ b/PSGSuite/Public/Sheets/Get-GSSheetInfo.ps1
@@ -38,6 +38,7 @@ function Get-GSSheetInfo {
 
     Gets the info for the SpreadSheet provided
     #>
+    [OutputType('Google.Apis.Sheets.v4.Data.Spreadsheet')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Sheets/New-GSSheet.ps1
+++ b/PSGSuite/Public/Sheets/New-GSSheet.ps1
@@ -2,27 +2,28 @@ function New-GSSheet {
     <#
     .SYNOPSIS
     Creates a new SpreadSheet
-    
+
     .DESCRIPTION
     Creates a new SpreadSheet
-    
+
     .PARAMETER Title
     The name of the new SpreadSheet
-    
+
     .PARAMETER User
     The user to create the Sheet for
-    
+
     .PARAMETER Launch
     If $true, opens the new SpreadSheet Url in your default browser
-    
+
     .EXAMPLE
     New-GSSheet -Title "Finance Workbook" -Launch
 
     Creates a new SpreadSheet titled "Finance Workbook" and opens it in the browser on creation
     #>
+    [OutputType('Google.Apis.Sheets.v4.Data.Spreadsheet')]
     [cmdletbinding()]
     Param
-    (      
+    (
         [parameter(Mandatory = $false)]
         [Alias('SheetTitle')]
         [String]

--- a/PSGSuite/Public/Tasks/Get-GSTask.ps1
+++ b/PSGSuite/Public/Tasks/Get-GSTask.ps1
@@ -2,36 +2,37 @@ function Get-GSTask {
     <#
     .SYNOPSIS
     Gets a specific Task or the list of Tasks
-    
+
     .DESCRIPTION
     Gets a specific Task or the list of Tasks
-    
+
     .PARAMETER User
     The User who owns the Task.
 
     Defaults to the AdminUser's email.
-    
+
     .PARAMETER Task
     The unique Id of the Task.
 
     If left blank, returns the list of Tasks on the Tasklist
-    
+
     .PARAMETER Tasklist
     The unique Id of the Tasklist the Task is on.
-    
+
     .PARAMETER PageSize
     Page size of the result set
-    
+
     .EXAMPLE
     Get-GSTasklist
 
     Gets the list of Tasklists owned by the AdminEmail user
-    
+
     .EXAMPLE
     Get-GSTasklist -Tasklist MTUzNTU0MDYscM0NjKDMTIyNjQ6MDow -User john@domain.com
 
     Gets the Tasklist matching the provided Id owned by John
     #>
+    [OutputType('Google.Apis.Tasks.v1.Data.Task')]
     [cmdletbinding(DefaultParameterSetName = "List")]
     Param
     (

--- a/PSGSuite/Public/Tasks/Get-GSTasklist.ps1
+++ b/PSGSuite/Public/Tasks/Get-GSTasklist.ps1
@@ -2,33 +2,34 @@ function Get-GSTasklist {
     <#
     .SYNOPSIS
     Gets a specific Tasklist or the list of Tasklists
-    
+
     .DESCRIPTION
     Gets a specific Tasklist or the list of Tasklists
-    
+
     .PARAMETER User
     The User who owns the Tasklist.
 
     Defaults to the AdminUser's email.
-    
+
     .PARAMETER Tasklist
     The unique Id of the Tasklist.
 
     If left blank, gets the full list of Tasklists
-    
+
     .PARAMETER PageSize
     Page size of the result set
-    
+
     .EXAMPLE
     Get-GSTasklist
 
     Gets the list of Tasklists owned by the AdminEmail user
-    
+
     .EXAMPLE
     Get-GSTasklist -Tasklist MTUzNTU0MDYscM0NjKDMTIyNjQ6MDow -User john@domain.com
 
     Gets the Tasklist matching the provided Id owned by John
     #>
+    [OutputType('Google.Apis.Tasks.v1.Data.TaskList')]
     [cmdletbinding(DefaultParameterSetName = "List")]
     Param
     (

--- a/PSGSuite/Public/Tasks/Move-GSTask.ps1
+++ b/PSGSuite/Public/Tasks/Move-GSTask.ps1
@@ -2,32 +2,33 @@ function Move-GSTask {
     <#
     .SYNOPSIS
     Moves the specified task to another position in the task list. This can include putting it as a child task under a new parent and/or move it to a different position among its sibling tasks.
-    
+
     .DESCRIPTION
     Moves the specified task to another position in the task list. This can include putting it as a child task under a new parent and/or move it to a different position among its sibling tasks.
-    
+
     .PARAMETER Tasklist
     The unique Id of the Tasklist where the Task currently resides
-    
+
     .PARAMETER Task
     The unique Id of the Task to move
 
     .PARAMETER Parent
-    Parent task identifier. If the task is created at the top level, this parameter is omitted. 
+    Parent task identifier. If the task is created at the top level, this parameter is omitted.
 
     .PARAMETER Previous
     Previous sibling task identifier. If the task is created at the first position among its siblings, this parameter is omitted.
-    
+
     .PARAMETER User
     The User who owns the Tasklist.
 
     Defaults to the AdminUser's email.
-    
+
     .EXAMPLE
     Clear-GSTasklist -Tasklist 'MTA3NjIwMjA1NTEzOTk0MjQ0OTk6NTMyNDY5NDk1NDM5MzMxO' -Confirm:$false
 
     Clears the specified Tasklist owned by the AdminEmail user and skips the confirmation check
     #>
+    [OutputType('Google.Apis.Tasks.v1.Data.Task')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Tasks/New-GSTask.ps1
+++ b/PSGSuite/Public/Tasks/New-GSTask.ps1
@@ -2,44 +2,45 @@ function New-GSTask {
     <#
     .SYNOPSIS
     Creates a new Task
-    
+
     .DESCRIPTION
     Creates a new Task
-    
+
     .PARAMETER Title
     The title of the new Task
-    
+
     .PARAMETER Tasklist
     The Id of the Tasklist to create the new Task on
-    
+
     .PARAMETER Completed
     The DateTime of the task completion
-    
+
     .PARAMETER Due
     The DateTime of the task due date
-    
+
     .PARAMETER Notes
     Notes describing the task
-    
+
     .PARAMETER Status
     Status of the task. This is either "needsAction" or "completed".
 
     .PARAMETER Parent
-    Parent task identifier. If the task is created at the top level, this parameter is omitted. 
+    Parent task identifier. If the task is created at the top level, this parameter is omitted.
 
     .PARAMETER Previous
     Previous sibling task identifier. If the task is created at the first position among its siblings, this parameter is omitted.
-    
+
     .PARAMETER User
     The User to create the Task for.
 
     Defaults to the AdminUser's email.
-    
+
     .EXAMPLE
     New-GSTask -Title 'Sweep kitchen','Mow lawn' -Tasklist MTA3NjIwMjA1NTEzOTk0MjQ0OTk6ODEzNTI1MjE3ODk0MTY2MDow
 
     Creates 2 new Tasks titled 'Sweep kitchen' and 'Mow lawn' for the AdminEmail user on the specified Tasklist Id
     #>
+    [OutputType('Google.Apis.Tasks.v1.Data.Task')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Tasks/New-GSTasklist.ps1
+++ b/PSGSuite/Public/Tasks/New-GSTasklist.ps1
@@ -2,23 +2,24 @@ function New-GSTasklist {
     <#
     .SYNOPSIS
     Creates a new Tasklist
-    
+
     .DESCRIPTION
     Creates a new Tasklist
-    
+
     .PARAMETER User
     The User to create the Tasklist for.
 
     Defaults to the AdminUser's email.
-    
+
     .PARAMETER Title
     The title of the new Tasklist
-    
+
     .EXAMPLE
     New-GSTasklist -Title 'Chores','Projects'
 
     Creates 2 new Tasklists titled 'Chores' and 'Projects' for the AdminEmail user
     #>
+    [OutputType('Google.Apis.Tasks.v1.Data.TaskList')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Tasks/Update-GSTask.ps1
+++ b/PSGSuite/Public/Tasks/Update-GSTask.ps1
@@ -2,47 +2,48 @@ function Update-GSTask {
     <#
     .SYNOPSIS
     Updates a Task
-    
+
     .DESCRIPTION
     Updates a Task
-    
+
     .PARAMETER Tasklist
     The Id of the Tasklist the Task is on
-    
+
     .PARAMETER Task
     The Id of the Task
-    
+
     .PARAMETER Title
     The title of the Task
-    
+
     .PARAMETER Completed
     The DateTime of the task completion
-    
+
     .PARAMETER Due
     The DateTime of the task due date
-    
+
     .PARAMETER Notes
     Notes describing the task
-    
+
     .PARAMETER Status
     Status of the task. This is either "needsAction" or "completed".
 
     .PARAMETER Parent
-    Parent task identifier. If the task is created at the top level, this parameter is omitted. 
+    Parent task identifier. If the task is created at the top level, this parameter is omitted.
 
     .PARAMETER Previous
     Previous sibling task identifier. If the task is created at the first position among its siblings, this parameter is omitted.
-    
+
     .PARAMETER User
     The User who owns the Task
 
     Defaults to the AdminUser's email.
-    
+
     .EXAMPLE
     Update-GSTask -Title 'Return Ben Crawford's call -Tasklist MTA3NjIwMjA1NTEzOTk0MjQ0OTk6ODEzNTI1MjE3ODk0MTY2MDow -Task 'MTA3NjIwMjA1NTEzOTk0MjQ0OTk6MDo4MjM4NDQ2MDA0MzIxMDEx' -Status completed
 
     Updates the specified Task's title and marks it as completed
     #>
+    [OutputType('Google.Apis.Tasks.v1.Data.Task')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Tasks/Update-GSTasklist.ps1
+++ b/PSGSuite/Public/Tasks/Update-GSTasklist.ps1
@@ -2,26 +2,27 @@ function Update-GSTasklist {
     <#
     .SYNOPSIS
     Updates a Tasklist title
-    
+
     .DESCRIPTION
     Updates a Tasklist title
-    
+
     .PARAMETER Tasklist
     The unique Id of the Tasklist to update
-    
+
     .PARAMETER Title
     The new title of the Tasklist
-    
+
     .PARAMETER User
     The User who owns the Tasklist.
 
     Defaults to the AdminUser's email.
-    
+
     .EXAMPLE
     Update-GSTasklist -Tasklist 'MTA3NjIwMjA1NTEzOTk0MjQ0OTk6NTMyNDY5NDk1NDM5MzMxOTow' -Title 'Hi-Pri Callbacks'
 
     Updates the specified TaskList with the new title 'Hi-Pri Callbacks'
     #>
+    [OutputType('Google.Apis.Tasks.v1.Data.TaskList')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/URL Shortener/Get-GSShortUrl.ps1
+++ b/PSGSuite/Public/URL Shortener/Get-GSShortUrl.ps1
@@ -2,30 +2,31 @@ function Get-GSShortUrl {
     <#
     .SYNOPSIS
     Gets information about a user's Short Url's created at https://goo.gl/
-    
+
     .DESCRIPTION
     Gets information about a user's Short Url's created at https://goo.gl/
-    
+
     .PARAMETER ShortUrl
     The Short Url to return information for. If excluded, returns the list of the user's Short Url's
-    
+
     .PARAMETER User
     The primary email of the user you would like to retrieve Short Url information for
 
     Defaults to the AdminEmail user
-    
+
     .PARAMETER Projection
-    	Additional information to return. 
+    	Additional information to return.
 
     Acceptable values are:
     * "ANALYTICS_CLICKS" - Returns short URL click counts.
     * "FULL" - Returns short URL click counts.
-    
+
     .EXAMPLE
     Get-GSShortUrl
 
     Gets the Short Url list of the AdminEmail user
     #>
+    [OutputType('Google.Apis.Urlshortener.v1.Data.Url')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/URL Shortener/New-GSShortUrl.ps1
+++ b/PSGSuite/Public/URL Shortener/New-GSShortUrl.ps1
@@ -2,23 +2,24 @@ function New-GSShortUrl {
     <#
     .SYNOPSIS
     Creates a new Short Url
-    
+
     .DESCRIPTION
     Creates a new Short Url
-    
+
     .PARAMETER LongUrl
     The full Url to shorten
-    
+
     .PARAMETER User
     The user to create the Short Url for
 
     Defaults to the AdminEmail user
-    
+
     .EXAMPLE
     New-GSShortUrl "http://ferrell.io"
 
     Creates a new Short Url pointing at http://ferrell.io/
     #>
+    [OutputType('Google.Apis.Urlshortener.v1.Data.Url')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Users/Get-GSUser.ps1
+++ b/PSGSuite/Public/Users/Get-GSUser.ps1
@@ -94,6 +94,7 @@ function Get-GSUser {
 
     Gets the list of users not currently enrolled in 2-Step Verification from the Contractors OrgUnit or any OrgUnits underneath it
     #>
+    [OutputType('Google.Apis.Admin.Directory.directory_v1.Data.User')]
     [cmdletbinding(DefaultParameterSetName = "Get")]
     Param
     (

--- a/PSGSuite/Public/Users/Get-GSUserAlias.ps1
+++ b/PSGSuite/Public/Users/Get-GSUserAlias.ps1
@@ -2,20 +2,21 @@ function Get-GSUserAlias {
     <#
     .SYNOPSIS
     Gets the specified G SUite User's aliases
-    
+
     .DESCRIPTION
     Gets the specified G SUite User's aliases
-    
+
     .PARAMETER User
     The primary email or UserID of the user who you are trying to get aliases for. You can exclude the '@domain.com' to insert the Domain in the config or use the special 'me' to indicate the AdminEmail in the config.
 
     Defaults to the AdminEmail in the config
-    
+
     .EXAMPLE
     Get-GSUserAlias
 
     Gets the list of aliases for the AdminEmail user
     #>
+    [OutputType('Google.Apis.Admin.Directory.directory_v1.Data.Alias')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Users/Get-GSUserPhoto.ps1
+++ b/PSGSuite/Public/Users/Get-GSUserPhoto.ps1
@@ -29,6 +29,7 @@ function Get-GSUserPhoto {
 
     Saves the Google user photo of the AdminEmail in the current working directory as a .png image
     #>
+    [OutputType('Google.Apis.Admin.Directory.directory_v1.Data.UserPhoto')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Users/New-GSUser.ps1
+++ b/PSGSuite/Public/Users/New-GSUser.ps1
@@ -108,6 +108,7 @@ function New-GSUser {
 
     Creates a user named John Smith and adds their work address, work phone, login_id and alternate non gsuite work email to the user object.
     #>
+    [OutputType('Google.Apis.Admin.Directory.directory_v1.Data.User')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Users/New-GSUserAlias.ps1
+++ b/PSGSuite/Public/Users/New-GSUserAlias.ps1
@@ -2,21 +2,22 @@ function New-GSUserAlias {
     <#
     .SYNOPSIS
     Creates a new alias for a G Suite user
-    
+
     .DESCRIPTION
     Creates a new alias for a G Suite user
-    
+
     .PARAMETER User
     The user to create the alias for
-    
+
     .PARAMETER Alias
     The alias or list of aliases to create for the user
-    
+
     .EXAMPLE
     New-GSUserAlias -User john.smith@domain.com -Alias 'jsmith@domain.com','johns@domain.com'
 
     Creates 2 new aliases for user John Smith as 'jsmith@domain.com' and 'johns@domain.com'
     #>
+    [OutputType('Google.Apis.Admin.Directory.directory_v1.Data.Alias')]
     [cmdletbinding()]
     Param
     (

--- a/PSGSuite/Public/Users/Restore-GSUser.ps1
+++ b/PSGSuite/Public/Users/Restore-GSUser.ps1
@@ -2,29 +2,30 @@ function Restore-GSUser {
     <#
     .SYNOPSIS
     Restores a deleted user
-    
+
     .DESCRIPTION
     Restores a deleted user
-    
+
     .PARAMETER User
     The email address of the user to restore
-    
+
     .PARAMETER Id
     The unique Id of the user to restore
-    
+
     .PARAMETER OrgUnitPath
     The OrgUnitPath to restore the user to
 
     Defaults to the root OrgUnit "/"
-    
+
     .PARAMETER RecentOnly
     If multiple users with the email address are found in deleted users, this forces restoration of the most recently deleted user. If not passed and multiple deleted users are found with the specified email address, you will be prompted to choose which you'd like to restore based on deletion time
-    
+
     .EXAMPLE
     Restore-GSUser -User john.smith@domain.com -OrgUnitPath "/Users/Rehires" -Confirm:$false
 
     Restores user John Smith to the OrgUnitPath "/Users/Rehires", skipping confirmation. If multiple accounts with the email "john.smith@domain.com" are found, the user is presented with a dialog to choose which account to restore based on deletion time
     #>
+    [OutputType('Google.Apis.Admin.Directory.directory_v1.Data.User')]
     [cmdletbinding(SupportsShouldProcess = $true,ConfirmImpact = "Medium",DefaultParameterSetName = 'User')]
     Param
     (

--- a/PSGSuite/Public/Users/Update-GSUser.ps1
+++ b/PSGSuite/Public/Users/Update-GSUser.ps1
@@ -114,6 +114,7 @@ function Update-GSUser {
 
     Updates user john.smith@domain.com with a new primary email of "johnathan.smith@domain.com", sets their Given Name to "Johnathan" and unsuspends them. Their previous primary email "john.smith@domain.com" will become an alias on their account automatically
     #>
+    [OutputType('Google.Apis.Admin.Directory.directory_v1.Data.User')]
     [cmdletbinding(SupportsShouldProcess = $true, ConfirmImpact = "High")]
     Param
     (

--- a/PSGSuite/Public/Users/Update-GSUserPhoto.ps1
+++ b/PSGSuite/Public/Users/Update-GSUserPhoto.ps1
@@ -17,6 +17,7 @@ function Update-GSUserPhoto {
 
     Updates the Google user photo of the AdminEmail with the image at the specified path
     #>
+    [OutputType('Google.Apis.Admin.Directory.directory_v1.Data.UserPhoto')]
     [cmdletbinding()]
     Param
     (

--- a/README.md
+++ b/README.md
@@ -136,6 +136,13 @@ Update-GSSheetValue               Export-GSSheet
 
 ### Most recent changes
 
+#### 2.21.3
+
+* [Issue #131](https://github.com/scrthq/PSGSuite/issues/131)
+  * Fixed: Changed `CodeReceiver` to use `PromptCodeReceiver` when client is PowerShell Core, as `LocalServerCodeReceiver` does not appear to redirect correctly and auth fails. Same behavior in Core regardless of OS.
+* Miscellaneous
+  * Added: `OutputType` to all functions that return standard objects.
+
 #### 2.21.2
 
 * [Issue #136](https://github.com/scrthq/PSGSuite/issues/136)


### PR DESCRIPTION
## 2.21.3

* [Issue #131](https://github.com/scrthq/PSGSuite/issues/131)
  * Fixed: Changed `CodeReceiver` to use `PromptCodeReceiver` when client is PowerShell Core, as `LocalServerCodeReceiver` does not appear to redirect correctly and auth fails. Same behavior in Core regardless of OS.
* Miscellaneous
  * Added: `OutputType` to all functions that return standard objects.