### PR TITLE
v2.22.0 - enhanced PSGSuiteConfig management and portability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ FunctionBackups/*
 BuildOutput/*
 *config.csv
 PSGSuite.zip
+PSGSuite*.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 * [Changelog](#changelog)
+  * [2.22.0](#2220)
   * [2.21.3](#2213)
   * [2.21.2](#2212)
   * [2.21.1](#2211)
@@ -67,6 +68,15 @@
       * [Functions Aliased](#functions-aliased)
 
 ***
+
+## 2.22.0
+
+* Miscellaneous: _Config management and portability updates_
+  * Added: `Export-PSGSuiteConfig` function to export key parts of your config in a transportable JSON file.
+  * Added: `Import-PSGSuiteConfig` function to import a config from a JSON file (i.e. one created with `Export-PSGSuiteConfig`) or from a JSON string (i.e. stored in a secure variable in a CI/CD system.)
+  * Updated: All config functions now store the P12Key or the ClientSecrets JSON string in the encrypted config directly. This is to allow removal of the secrets files as well as enable PSGSuite to run in a contained environment via importing the config from a secure JSON string.
+  * Updated: `[Get|Set|Switch]-PSGSuiteConfig` to include the P12Key and ClientSecrets parameters that enable housing of the key/secret directly on the encrypted config.
+  * Updated: If the global PSGSuite variable `$global:PSGSuite` exists during module import, it will default to using that as it's configuration, otherwise it will import the default config if set.
 
 ## 2.21.3
 

--- a/PSGSuite/PSGSuite.psd1
+++ b/PSGSuite/PSGSuite.psd1
@@ -12,7 +12,7 @@
     RootModule            = 'PSGSuite.psm1'
 
     # Version number of this module.
-    ModuleVersion         = '2.21.3'
+    ModuleVersion         = '2.22.0'
 
     # ID used to uniquely identify this module
     GUID                  = '9d751152-e83e-40bb-a6db-4c329092aaec'

--- a/PSGSuite/Public/Configuration/Export-PSGSuiteConfig.ps1
+++ b/PSGSuite/Public/Configuration/Export-PSGSuiteConfig.ps1
@@ -1,0 +1,52 @@
+function Export-PSGSuiteConfig {
+    <#
+    .SYNOPSIS
+    Allows you to export an unecrypted PSGSuite config in a portable JSON string format. Useful for moving a config to a new machine or storing the full as an encrypted string in your CI/CD / Automation tools.
+
+    .DESCRIPTION
+    Allows you to export an unecrypted PSGSuite config in a portable JSON string format. Useful for moving a config to a new machine or storing the full as an encrypted string in your CI/CD / Automation tools.
+
+    .PARAMETER Path
+    The path you would like to save the JSON file to. Defaults to a named path in the current directory.
+
+    .PARAMETER ConfigName
+    The config that you would like to export. Defaults to the currently loaded config.
+
+    .EXAMPLE
+    Export-PSGSuiteConfig -ConfigName Personal -Path ".\PSGSuite_personal_config.json"
+
+    Exports the config named 'Personal' to the path specified.
+    #>
+    [CmdletBinding()]
+    Param (
+        [parameter(Mandatory = $false,Position = 0)]
+        [Alias('OutPath','OutFile','JsonPath')]
+        [String]
+        $Path,
+        [parameter(Mandatory = $false)]
+        [String]
+        $ConfigName = $script:PSGSuite.ConfigName
+    )
+    Begin {
+        $baseConf = if ($PSBoundParameters.Keys -contains 'ConfigName'){
+            Get-PSGSuiteConfig -ConfigName $ConfigName -NoImport -PassThru -Verbose:$false
+        }
+        else {
+            Show-PSGSuiteConfig -Verbose:$false
+        }
+        if ($PSBoundParameters.Keys -notcontains 'Path') {
+            $Path = (Join-Path $PWD.Path "PSGSuite_$($baseConf.AdminEmail)_$($baseConf.ConfigName).json")
+        }
+    }
+    Process {
+        try {
+            Write-Verbose "Updating current saved config for '$ConfigName' with P12Key and ClientSecrets contents if missing."
+            $baseConf | Set-PSGSuiteConfig -NoImport -Verbose:$false
+            Write-Verbose "Exporting config '$ConfigName' to path: $Path"
+            Get-PSGSuiteConfig -ConfigName $ConfigName -NoImport -PassThru -Verbose:$false | Select-Object ConfigName,P12Key,ClientSecrets,AppEmail,AdminEmail,CustomerId,Domain,Preference | ConvertTo-Json -Depth 5 -Compress -Verbose:$false | Set-Content -Path $Path -Verbose:$false
+        }
+        catch {
+            $PSCmdlet.ThrowTerminatingError($_)
+        }
+    }
+}

--- a/PSGSuite/Public/Configuration/Get-PSGSuiteConfig.ps1
+++ b/PSGSuite/Public/Configuration/Get-PSGSuiteConfig.ps1
@@ -87,6 +87,7 @@ function Get-PSGSuiteConfig {
     $decryptedConfig = $encConf |
         Select-Object -Property @{l = 'ConfigName';e = {$choice}},
                                 @{l = 'P12KeyPath';e = {Decrypt $_.P12KeyPath}},
+                                P12Key,
                                 @{l = 'ClientSecretsPath';e = {Decrypt $_.ClientSecretsPath}},
                                 @{l = 'ClientSecrets';e = {Decrypt $_.ClientSecrets}},
                                 @{l = 'AppEmail';e = {Decrypt $_.AppEmail}},

--- a/PSGSuite/Public/Configuration/Import-PSGSuiteConfig.ps1
+++ b/PSGSuite/Public/Configuration/Import-PSGSuiteConfig.ps1
@@ -1,0 +1,69 @@
+function Import-PSGSuiteConfig {
+    <#
+    .SYNOPSIS
+    Allows you to import an unecrypted PSGSuite config from a portable JSON string format, typically created with Export-PSGSuiteConfig. Useful for moving a config to a new machine or storing the full as an encrypted string in your CI/CD / Automation tools.
+
+    .DESCRIPTION
+    Allows you to import an unecrypted PSGSuite config from a portable JSON string format, typically created with Export-PSGSuiteConfig. Useful for moving a config to a new machine or storing the full as an encrypted string in your CI/CD / Automation tools.
+
+    .PARAMETER Json
+    The Json string to import.
+
+    .PARAMETER Path
+    The path of the Json file you would like import.
+
+    .PARAMETER Temporary
+    If $true, the imported config is not stored in the config file and the imported config persists only for the current session.
+
+    .PARAMETER PassThru
+    If $true, outputs the resulting config object to the pipeline.
+
+    .EXAMPLE
+    Import-Module PSGSuite -MinimumVersion 2.22.0
+    Import-PSGSuiteConfig -Json '$(PSGSuiteConfigJson)' -Temporary
+
+    Azure Pipelines inline script task that uses a Secure Variable named 'PSGSuiteConfigJson' with the Config JSON string stored in it, removing the need to include credential or key files anywhere.
+    #>
+    [CmdletBinding(DefaultParameterSetName = "Json")]
+    Param (
+        [parameter(Mandatory = $true,Position = 0,ValueFromPipeline = $true,ParameterSetName = "Json")]
+        [Alias('J')]
+        [String]
+        $Json,
+        [parameter(Mandatory = $true,ValueFromPipelineByPropertyName = $true,ParameterSetName = "Path")]
+        [Alias('P')]
+        [String]
+        $Path,
+        [parameter(Mandatory = $false)]
+        [Alias('Temp','T')]
+        [Switch]
+        $Temporary,
+        [parameter(Mandatory = $false)]
+        [Switch]
+        $PassThru
+    )
+    Process {
+        try {
+            switch ($PSCmdlet.ParameterSetName) {
+                Path {
+                    Write-Verbose "Importing config from path: $Path"
+                    $script:PSGSuite = (ConvertFrom-Json (Get-Content $Path -Raw))
+                }
+                Json {
+                    Write-Verbose "Importing config from Json string"
+                    $script:PSGSuite = (ConvertFrom-Json $Json)
+                }
+            }
+            if (-not $Temporary) {
+                Write-Verbose "Saving imported config"
+                $script:PSGSuite | Set-PSGSuiteConfig
+            }
+            if ($PassThru) {
+                return $script:PSGSuite
+            }
+        }
+        catch {
+            $PSCmdlet.ThrowTerminatingError($_)
+        }
+    }
+}

--- a/PSGSuite/Public/Configuration/Switch-PSGSuiteConfig.ps1
+++ b/PSGSuite/Public/Configuration/Switch-PSGSuiteConfig.ps1
@@ -77,6 +77,7 @@
             $script:PSGSuite = [PSCustomObject]($fullConf[$choice]) |
                 Select-Object -Property @{l = 'ConfigName';e = {$choice}},
                                         @{l = 'P12KeyPath';e = {Decrypt $_.P12KeyPath}},
+                                        P12Key,
                                         @{l = 'ClientSecretsPath';e = {Decrypt $_.ClientSecretsPath}},
                                         @{l = 'ClientSecrets';e = {Decrypt $_.ClientSecrets}},
                                         @{l = 'AppEmail';e = {Decrypt $_.AppEmail}},

--- a/README.md
+++ b/README.md
@@ -136,6 +136,15 @@ Update-GSSheetValue               Export-GSSheet
 
 ### Most recent changes
 
+#### 2.22.0
+
+* Miscellaneous: _Config management and portability updates_
+  * Added: `Export-PSGSuiteConfig` function to export key parts of your config in a transportable JSON file.
+  * Added: `Import-PSGSuiteConfig` function to import a config from a JSON file (i.e. one created with `Export-PSGSuiteConfig`) or from a JSON string (i.e. stored in a secure variable in a CI/CD system.)
+  * Updated: All config functions now store the P12Key or the ClientSecrets JSON string in the encrypted config directly. This is to allow removal of the secrets files as well as enable PSGSuite to run in a contained environment via importing the config from a secure JSON string.
+  * Updated: `[Get|Set|Switch]-PSGSuiteConfig` to include the P12Key and ClientSecrets parameters that enable housing of the key/secret directly on the encrypted config.
+  * Updated: If the global PSGSuite variable `$global:PSGSuite` exists during module import, it will default to using that as it's configuration, otherwise it will import the default config if set.
+
 #### 2.21.3
 
 * [Issue #131](https://github.com/scrthq/PSGSuite/issues/131)

--- a/psake.ps1
+++ b/psake.ps1
@@ -177,7 +177,17 @@ try {
         `$Script:ConfigName = `$ConfigName
     }
     try {
-        Get-PSGSuiteConfig @confParams -ErrorAction Stop
+        if (`$global:PSGSuite) {
+            Write-Warning "Using config `$(if (`$global:PSGSuite.ConfigName){"name '`$(`$global:PSGSuite.ConfigName)' "})found in variable: ```$global:PSGSuite"
+            Write-Verbose "`$((`$global:PSGSuite | Format-List | Out-String).Trim())"
+            if (`$global:PSGSuite -is [System.Collections.Hashtable]) {
+                `$global:PSGSuite = New-Object PSObject -Property `$global:PSGSuite
+            }
+            `$script:PSGSuite = `$global:PSGSuite
+        }
+        else {
+            Get-PSGSuiteConfig @confParams -ErrorAction Stop
+        }
     }
     catch {
         if (Test-Path "`$ModuleRoot\`$env:USERNAME-`$env:COMPUTERNAME-`$env:PSGSuiteDefaultDomain-PSGSuite.xml") {


### PR DESCRIPTION
## 2.22.0

* Miscellaneous: _Config management and portability updates_
  * Added: `Export-PSGSuiteConfig` function to export key parts of your config in a transportable JSON file.
  * Added: `Import-PSGSuiteConfig` function to import a config from a JSON file (i.e. one created with `Export-PSGSuiteConfig`) or from a JSON string (i.e. stored in a secure variable in a CI/CD system.)
  * Updated: All config functions now store the P12Key or the ClientSecrets JSON string in the encrypted config directly. This is to allow removal of the secrets files as well as enable PSGSuite to run in a contained environment via importing the config from a secure JSON string.
  * Updated: `[Get|Set|Switch]-PSGSuiteConfig` to include the P12Key and ClientSecrets parameters that enable housing of the key/secret directly on the encrypted config.
  * Updated: If the global PSGSuite variable `$global:PSGSuite` exists during module import, it will default to using that as it's configuration, otherwise it will import the default config if set.