### PR TITLE
fixed [System.Console]::CursorVisible call error from ISE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 * [Changelog](#changelog)
+  * [2.22.3](#2223)
   * [2.22.2](#2222)
   * [2.22.1](#2221)
   * [2.22.0](#2220)
@@ -70,6 +71,11 @@
       * [Functions Aliased](#functions-aliased)
 
 ***
+
+## 2.22.3
+
+* [Issue #144](https://github.com/scrthq/PSGSuite/issues/144)
+  * Updated: `Start-GSDriveFileUpload` to not call `[System.Console]::CursorVisible` when `$Host` is PowerShell ISE
 
 ## 2.22.2
 

--- a/PSGSuite/PSGSuite.psd1
+++ b/PSGSuite/PSGSuite.psd1
@@ -12,7 +12,7 @@
     RootModule            = 'PSGSuite.psm1'
 
     # Version number of this module.
-    ModuleVersion         = '2.22.2'
+    ModuleVersion         = '2.22.3'
 
     # ID used to uniquely identify this module
     GUID                  = '9d751152-e83e-40bb-a6db-4c329092aaec'

--- a/PSGSuite/Public/Drive/Start-GSDriveFileUpload.ps1
+++ b/PSGSuite/Public/Drive/Start-GSDriveFileUpload.ps1
@@ -221,7 +221,9 @@ function Start-GSDriveFileUpload {
             }
         }
         finally {
-            [Console]::CursorVisible = $true
+            if ($Host.Name -and $Host.Name -notlike "Windows*PowerShell*ISE*") {
+                [System.Console]::CursorVisible = $true
+            }
         }
     }
     End {
@@ -326,7 +328,9 @@ function Start-GSDriveFileUpload {
                 }
             }
             finally {
-                [Console]::CursorVisible = $true
+                if ($Host.Name -and $Host.Name -notlike "Windows*PowerShell*ISE*") {
+                    [System.Console]::CursorVisible = $true
+                }
                 Stop-GSDriveFileUpload
             }
         }

--- a/README.md
+++ b/README.md
@@ -138,9 +138,7 @@ Update-GSSheetValue               Export-GSSheet
 
 [Full CHANGELOG here](https://github.com/scrthq/PSGSuite/blob/master/CHANGELOG.md)
 
-#### 2.22.2
+#### 2.22.3
 
 * [Issue #144](https://github.com/scrthq/PSGSuite/issues/144)
-  * Updated: `Start-GSDriveFileUpload` to `Dispose()` open streams once uploads are completed.
-  * Added: `Stop-GSDriveFileUpload` to enable cleanup of any remaining open streams.
-  * Updated: `Get-GSDriveFileUpload` to `Dispose()` any completed streams that are still open.
+  * Updated: `Start-GSDriveFileUpload` to not call `[System.Console]::CursorVisible` when `$Host` is PowerShell ISE


### PR DESCRIPTION
## 2.22.3

* [Issue #144](https://github.com/scrthq/PSGSuite/issues/144)
  * Updated: `Start-GSDriveFileUpload` to not call `[System.Console]::CursorVisible` when `$Host` is PowerShell ISE