### PR TITLE
!deploy v2.28.1 to resolve #188

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 * [PSGSuite - ChangeLog](#psgsuite---changelog)
+  * [2.28.1](#2281)
   * [2.28.0](#2280)
   * [2.27.0](#2270)
   * [2.26.4](#2264)
@@ -87,6 +88,11 @@
 ***
 
 # PSGSuite - ChangeLog
+
+## 2.28.1
+
+* [Issue #188](https://github.com/scrthq/PSGSuite/issues/188)
+  * Fixed: `Get-SafeFileName` correctly replaces special RegEx chars with underscores as well.
 
 ## 2.28.0
 

--- a/PSGSuite/PSGSuite.psd1
+++ b/PSGSuite/PSGSuite.psd1
@@ -12,7 +12,7 @@
     RootModule            = 'PSGSuite.psm1'
 
     # Version number of this module.
-    ModuleVersion         = '2.28.0'
+    ModuleVersion         = '2.28.1'
 
     # ID used to uniquely identify this module
     GUID                  = '9d751152-e83e-40bb-a6db-4c329092aaec'

--- a/PSGSuite/Private/Get-SafeFileName.ps1
+++ b/PSGSuite/Private/Get-SafeFileName.ps1
@@ -6,6 +6,6 @@ function Get-SafeFileName {
         $Name
     )
     Process {
-        $Name -replace "[$(([System.IO.Path]::GetInvalidFileNameChars() + [System.IO.Path]::GetInvalidPathChars()) -join '')]","_"
+        $Name -replace "[$([RegEx]::Escape("$(([System.IO.Path]::GetInvalidFileNameChars() + [System.IO.Path]::GetInvalidPathChars()) -join '')"))]","_"
     }
 }

--- a/README.md
+++ b/README.md
@@ -158,6 +158,11 @@ All other functions are either intact or have an alias included to support backw
 
 [Full CHANGELOG here](https://github.com/scrthq/PSGSuite/blob/master/CHANGELOG.md)
 
+#### 2.28.1
+
+* [Issue #188](https://github.com/scrthq/PSGSuite/issues/188)
+  * Fixed: `Get-SafeFileName` correctly replaces special RegEx chars with underscores as well.
+
 #### 2.28.0
 
 * [Issue #188](https://github.com/scrthq/PSGSuite/issues/188)


### PR DESCRIPTION
## 2.28.1

* [Issue #188](https://github.com/scrthq/PSGSuite/issues/188)
  * Fixed: Get-SafeFileName correctly replaces special RegEx chars with underscores as well.