### PR TITLE
pushing fix for #194 for Update-GSChromeDevice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 * [PSGSuite - ChangeLog](#psgsuite---changelog)
+  * [2.28.2](#2282)
   * [2.28.1](#2281)
   * [2.28.0](#2280)
   * [2.27.0](#2270)
@@ -88,6 +89,15 @@
 ***
 
 # PSGSuite - ChangeLog
+
+## 2.28.2
+
+* [Issue #194](https://github.com/scrthq/PSGSuite/issues/194)
+  * Fixed: Parameters not setting correctyl on `Update-GSChromeOSDevice`:
+    * `AnnotatedAssetId [string]`
+    * `AnnotatedLocation [string]`
+    * `AnnotatedUser [string]`
+    * `Notes [string]`
 
 ## 2.28.1
 

--- a/PSGSuite/PSGSuite.psd1
+++ b/PSGSuite/PSGSuite.psd1
@@ -12,7 +12,7 @@
     RootModule            = 'PSGSuite.psm1'
 
     # Version number of this module.
-    ModuleVersion         = '2.28.1'
+    ModuleVersion         = '2.28.2'
 
     # ID used to uniquely identify this module
     GUID                  = '9d751152-e83e-40bb-a6db-4c329092aaec'

--- a/PSGSuite/Public/Security/Update-GSChromeOSDevice.ps1
+++ b/PSGSuite/Public/Security/Update-GSChromeOSDevice.ps1
@@ -152,7 +152,7 @@ function Update-GSChromeOSDevice {
             foreach ($dev in $ResourceId) {
                 try {
                     Write-Verbose "Updating Chrome OS Device '$dev'"
-                    $request = $service.Chromeosdevices.Patch($actionBody,$customerId,$dev)
+                    $request = $service.Chromeosdevices.Patch($body,$customerId,$dev)
                     $request.Execute()
                 }
                 catch {

--- a/README.md
+++ b/README.md
@@ -158,6 +158,15 @@ All other functions are either intact or have an alias included to support backw
 
 [Full CHANGELOG here](https://github.com/scrthq/PSGSuite/blob/master/CHANGELOG.md)
 
+#### 2.28.2
+
+* [Issue #194](https://github.com/scrthq/PSGSuite/issues/194)
+  * Fixed: Parameters not setting correctyl on `Update-GSChromeOSDevice`:
+    * `AnnotatedAssetId [string]`
+    * `AnnotatedLocation [string]`
+    * `AnnotatedUser [string]`
+    * `Notes [string]`
+
 #### 2.28.1
 
 * [Issue #188](https://github.com/scrthq/PSGSuite/issues/188)


### PR DESCRIPTION
## 2.28.2

* [Issue #194](https://github.com/scrthq/PSGSuite/issues/194)
  * Fixed: Parameters not setting correctyl on `Update-GSChromeOSDevice`:
    * `AnnotatedAssetId [string]`
    * `AnnotatedLocation [string]`
    * `AnnotatedUser [string]`
    * `Notes [string]`