### PR TITLE
!deploy v2.29.0 with multiple fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-* [PSGSuite - ChangeLog](#psgsuite---changelog)
+* [PSGSuite - ChangeLog](#PSGSuite---ChangeLog)
+  * [2.29.0](#2290)
   * [2.28.2](#2282)
   * [2.28.1](#2281)
   * [2.28.0](#2280)
@@ -80,15 +81,24 @@
   * [2.0.2](#202)
   * [2.0.1](#201)
   * [2.0.0](#200)
-    * [New Functionality](#new-functionality)
-    * [Breaking Changes in 2.0.0](#breaking-changes-in-200)
-      * [Gmail Delegation Management Removed](#gmail-delegation-management-removed)
-      * [Functions Removed](#functions-removed)
-      * [Functions Aliased](#functions-aliased)
+    * [New Functionality](#New-Functionality)
+    * [Breaking Changes in 2.0.0](#Breaking-Changes-in-200)
+      * [Gmail Delegation Management Removed](#Gmail-Delegation-Management-Removed)
+      * [Functions Removed](#Functions-Removed)
+      * [Functions Aliased](#Functions-Aliased)
 
 ***
 
 # PSGSuite - ChangeLog
+
+## 2.29.0
+
+* [Issue #201](https://github.com/scrthq/PSGSuite/issues/201)
+  * Fixed: Fields parameter on remaining `*-GSDriveFile` functions
+* [Issue #197](https://github.com/scrthq/PSGSuite/issues/197)
+  * Updated: All remaining `*-TeamDrive` functions now use the new Drives namespace. All previous functions names have been converted to aliases to maintain backwards compatibility.
+  * Added: `Hide-GSDrive`
+  * Added: `Show-GSDrive`
 
 ## 2.28.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,9 @@
   * Updated: All remaining `*-TeamDrive` functions now use the new Drives namespace. All previous functions names have been converted to aliases to maintain backwards compatibility.
   * Added: `Hide-GSDrive`
   * Added: `Show-GSDrive`
+* [Issue #184](https://github.com/scrthq/PSGSuite/issues/184)
+  * Added: `EnableCollaborativeInbox` parameter to `Update-GSGroupSettings`
+  * Added: `WhoCanDiscoverGroup` parameter to `Update-GSGroupSettings`
 
 ## 2.28.2
 

--- a/PSGSuite/Aliases/PSGSuite.Aliases.ps1
+++ b/PSGSuite/Aliases/PSGSuite.Aliases.ps1
@@ -1,3 +1,4 @@
+#    Alias  =>  =>  =>  =>  =>  =>  =>  =>  Function
 @{
     'Add-GSDriveFilePermissions'        = 'Add-GSDrivePermission'
     'Export-PSGSuiteConfiguration'      = 'Set-PSGSuiteConfig'
@@ -33,10 +34,13 @@
     'Import-PSGSuiteConfiguration'      = 'Get-PSGSuiteConfig'
     'Move-GSGmailMessageToTrash'        = 'Remove-GSGmailMessage'
     'New-GSCalendarResource'            = 'New-GSResource'
+    'New-GSTeamDrive'                   = 'New-GSDrive'
     'Remove-GSGmailMessageFromTrash'    = 'Restore-GSGmailMessage'
+    'Remove-GSTeamDrive'                = 'Remove-GSDrive'
     'Set-PSGSuiteDefaultDomain'         = 'Switch-PSGSuiteConfig'
     'Switch-PSGSuiteDomain'             = 'Switch-PSGSuiteConfig'
     'Update-GSCalendarResource'         = 'Update-GSResource'
     'Update-GSGmailSendAsSettings'      = 'Update-GSGmailSendAsAlias'
     'Update-GSSheetValue'               = 'Export-GSSheet'
+    'Update-GSTeamDrive'                = 'Update-GSDrive'
 }

--- a/PSGSuite/PSGSuite.psd1
+++ b/PSGSuite/PSGSuite.psd1
@@ -12,7 +12,7 @@
     RootModule            = 'PSGSuite.psm1'
 
     # Version number of this module.
-    ModuleVersion         = '2.28.2'
+    ModuleVersion         = '2.29.0'
 
     # ID used to uniquely identify this module
     GUID                  = '9d751152-e83e-40bb-a6db-4c329092aaec'

--- a/PSGSuite/Public/Drive/Copy-GSDriveFile.ps1
+++ b/PSGSuite/Public/Drive/Copy-GSDriveFile.ps1
@@ -84,7 +84,7 @@ function Copy-GSDriveFile {
                 }
             }
         }
-        elseif ($Fields) {
+        elseif ($PSBoundParameters.ContainsKey('Fields')) {
             $fs = $Fields
         }
     }

--- a/PSGSuite/Public/Drive/Export-GSDriveFile.ps1
+++ b/PSGSuite/Public/Drive/Export-GSDriveFile.ps1
@@ -99,7 +99,7 @@ function Export-GSDriveFile {
                 }
             }
         }
-        elseif ($Fields) {
+        elseif ($PSBoundParameters.ContainsKey('Fields')) {
             $fs = $Fields
         }
         $mimeHash = @{

--- a/PSGSuite/Public/Drive/Hide-GSDrive.ps1
+++ b/PSGSuite/Public/Drive/Hide-GSDrive.ps1
@@ -1,0 +1,64 @@
+function Hide-GSDrive {
+    <#
+    .SYNOPSIS
+    Hides a Shared Drive from the default view
+
+    .DESCRIPTION
+    Hides a Shared Drive from the default view
+
+    .PARAMETER DriveId
+    The unique Id of the Shared Drive to hide
+
+    .PARAMETER User
+    The email or unique Id of the user who you'd like to hide the Shared Drive for.
+
+    Defaults to the AdminEmail user.
+
+    .EXAMPLE
+    Hide-GSDrive -DriveId $driveIds
+
+    Hides the specified DriveIds for the AdminEmail user
+    #>
+    [OutputType('Google.Apis.Drive.v3.Data.Drive')]
+    [cmdletbinding()]
+    Param
+    (
+        [parameter(Mandatory = $true,ValueFromPipelineByPropertyName = $true,ParameterSetName = "Get")]
+        [Alias('Id','TeamDriveId')]
+        [String[]]
+        $DriveId,
+        [parameter(Mandatory = $false,Position = 0,ValueFromPipelineByPropertyName = $true)]
+        [Alias('Owner','PrimaryEmail','UserKey','Mail')]
+        [string]
+        $User = $Script:PSGSuite.AdminEmail
+    )
+    Process {
+        if ($User -ceq 'me') {
+            $User = $Script:PSGSuite.AdminEmail
+        }
+        elseif ($User -notlike "*@*.*") {
+            $User = "$($User)@$($Script:PSGSuite.Domain)"
+        }
+        $serviceParams = @{
+            Scope       = 'https://www.googleapis.com/auth/drive'
+            ServiceType = 'Google.Apis.Drive.v3.DriveService'
+            User        = $User
+        }
+        $service = New-GoogleService @serviceParams
+        foreach ($id in $DriveId) {
+            try {
+                $request = $service.Drives.Hide($id)
+                Write-Verbose "Hiding Shared Drive '$id' for user '$User'"
+                $request.Execute() | Add-Member -MemberType NoteProperty -Name 'User' -Value $User -PassThru
+            }
+            catch {
+                if ($ErrorActionPreference -eq 'Stop') {
+                    $PSCmdlet.ThrowTerminatingError($_)
+                }
+                else {
+                    Write-Error $_
+                }
+            }
+        }
+    }
+}

--- a/PSGSuite/Public/Drive/New-GSDrive.ps1
+++ b/PSGSuite/Public/Drive/New-GSDrive.ps1
@@ -1,68 +1,68 @@
-function New-GSTeamDrive {
+function New-GSDrive {
     <#
     .SYNOPSIS
-    Creates a new Team Drive
+    Creates a new Shared Drive
 
     .DESCRIPTION
-    Creates a new Team Drive
+    Creates a new Shared Drive
 
     .PARAMETER Name
-    The name of the Team Drive
+    The name of the Shared Drive
 
     .PARAMETER User
-    The user to create the Team Drive for (must have permissions to create Team Drives)
+    The user to create the Shared Drive for (must have permissions to create Shared Drives)
 
     .PARAMETER RequestId
-    An ID, such as a random UUID, which uniquely identifies this user's request for idempotent creation of a Team Drive. A repeated request by the same user and with the same request ID will avoid creating duplicates by attempting to create the same Team Drive. If the Team Drive already exists a 409 error will be returned.
+    An ID, such as a random UUID, which uniquely identifies this user's request for idempotent creation of a Shared Drive. A repeated request by the same user and with the same request ID will avoid creating duplicates by attempting to create the same Shared Drive. If the Shared Drive already exists a 409 error will be returned.
 
     .PARAMETER CanAddChildren
-    Whether the current user can add children to folders in this Team Drive
+    Whether the current user can add children to folders in this Shared Drive
 
-    .PARAMETER CanChangeTeamDriveBackground
-    Whether the current user can change the background of this Team Drive
+    .PARAMETER CanChangeDriveBackground
+    Whether the current user can change the background of this Shared Drive
 
     .PARAMETER CanComment
-    Whether the current user can comment on files in this Team Drive
+    Whether the current user can comment on files in this Shared Drive
 
     .PARAMETER CanCopy
-    Whether the current user can copy files in this Team Drive
+    Whether the current user can copy files in this Shared Drive
 
-    .PARAMETER CanDeleteTeamDrive
-    Whether the current user can delete this Team Drive. Attempting to delete the Team Drive may still fail if there are untrashed items inside the Team Drive
+    .PARAMETER CanDeleteDrive
+    Whether the current user can delete this Shared Drive. Attempting to delete the Shared Drive may still fail if there are untrashed items inside the Shared Drive
 
     .PARAMETER CanDownload
-    Whether the current user can download files in this Team Drive
+    Whether the current user can download files in this Shared Drive
 
     .PARAMETER CanEdit
-    Whether the current user can edit files in this Team Drive
+    Whether the current user can edit files in this Shared Drive
 
     .PARAMETER CanListChildren
-    Whether the current user can list the children of folders in this Team Drive
+    Whether the current user can list the children of folders in this Shared Drive
 
     .PARAMETER CanManageMembers
-    Whether the current user can add members to this Team Drive or remove them or change their role
+    Whether the current user can add members to this Shared Drive or remove them or change their role
 
     .PARAMETER CanReadRevisions
-    Whether the current user can read the revisions resource of files in this Team Drive
+    Whether the current user can read the revisions resource of files in this Shared Drive
 
     .PARAMETER CanRemoveChildren
-    Whether the current user can remove children from folders in this Team Drive
+    Whether the current user can remove children from folders in this Shared Drive
 
     .PARAMETER CanRename
-    Whether the current user can rename files or folders in this Team Drive
+    Whether the current user can rename files or folders in this Shared Drive
 
-    .PARAMETER CanRenameTeamDrive
-    Whether the current user can rename this Team Drive
+    .PARAMETER CanRenameDrive
+    Whether the current user can rename this Shared Drive
 
     .PARAMETER CanShare
-    Whether the current user can share files or folders in this Team Drive
+    Whether the current user can share files or folders in this Shared Drive
 
     .EXAMPLE
-    New-GSTeamDrive -Name "Training Docs"
+    New-GSDrive -Name "Training Docs"
 
-    Creates a new Team Drive named "Training Docs"
+    Creates a new Shared Drive named "Training Docs"
     #>
-    [OutputType('Google.Apis.Drive.v3.Data.TeamDrive')]
+    [OutputType('Google.Apis.Drive.v3.Data.Drive')]
     [cmdletbinding()]
     Param
     (
@@ -81,8 +81,9 @@ function New-GSTeamDrive {
         [Switch]
         $CanAddChildren,
         [parameter(Mandatory = $false)]
+        [Alias('CanChangeTeamDriveBackground')]
         [Switch]
-        $CanChangeTeamDriveBackground,
+        $CanChangeDriveBackground,
         [parameter(Mandatory = $false)]
         [Switch]
         $CanComment,
@@ -90,8 +91,9 @@ function New-GSTeamDrive {
         [Switch]
         $CanCopy,
         [parameter(Mandatory = $false)]
+        [Alias('CanDeleteTeamDrive')]
         [Switch]
-        $CanDeleteTeamDrive,
+        $CanDeleteDrive,
         [parameter(Mandatory = $false)]
         [Switch]
         $CanDownload,
@@ -114,8 +116,9 @@ function New-GSTeamDrive {
         [Switch]
         $CanRename,
         [parameter(Mandatory = $false)]
+        [Alias('CanRenameTeamDrive')]
         [Switch]
-        $CanRenameTeamDrive,
+        $CanRenameDrive,
         [parameter(Mandatory = $false)]
         [Switch]
         $CanShare
@@ -134,8 +137,8 @@ function New-GSTeamDrive {
         }
         $service = New-GoogleService @serviceParams
         try {
-            $body = New-Object 'Google.Apis.Drive.v3.Data.TeamDrive'
-            $capabilities = New-Object 'Google.Apis.Drive.v3.Data.TeamDrive+CapabilitiesData'
+            $body = New-Object 'Google.Apis.Drive.v3.Data.Drive'
+            $capabilities = New-Object 'Google.Apis.Drive.v3.Data.Drive+CapabilitiesData'
             foreach ($key in $PSBoundParameters.Keys) {
                 switch ($key) {
                     Default {
@@ -149,8 +152,8 @@ function New-GSTeamDrive {
                 }
             }
             $body.Capabilities = $capabilities
-            $request = $service.Teamdrives.Create($body,$RequestId)
-            Write-Verbose "Creating Team Drive '$Name' for user '$User'"
+            $request = $service.Drives.Create($body,$RequestId)
+            Write-Verbose "Creating Shared Drive '$Name' for user '$User'"
             $request.Execute() | Add-Member -MemberType NoteProperty -Name 'User' -Value $User -PassThru | Add-Member -MemberType NoteProperty -Name 'RequestId' -Value $RequestId -PassThru
         }
         catch {

--- a/PSGSuite/Public/Drive/New-GSDriveFile.ps1
+++ b/PSGSuite/Public/Drive/New-GSDriveFile.ps1
@@ -186,7 +186,7 @@ function New-GSDriveFile {
                 }
             }
         }
-        elseif ($Fields) {
+        elseif ($PSBoundParameters.ContainsKey('Fields')) {
             $fs = $Fields
         }
     }

--- a/PSGSuite/Public/Drive/Remove-GSDrive.ps1
+++ b/PSGSuite/Public/Drive/Remove-GSDrive.ps1
@@ -1,31 +1,31 @@
-function Remove-GSTeamDrive {
+function Remove-GSDrive {
     <#
     .SYNOPSIS
-    Removes a Team Drive
+    Removes a Shared Drive
 
     .DESCRIPTION
-    Removes a Team Drive
+    Removes a Shared Drive
 
-    .PARAMETER TeamDriveId
-    The Id of the Team Drive to remove
+    .PARAMETER DriveId
+    The Id of the Shared Drive to remove
 
     .PARAMETER User
-    The email or unique Id of the user with permission to delete the Team Drive
+    The email or unique Id of the user with permission to delete the Shared Drive
 
     Defaults to the AdminEmail user
 
     .EXAMPLE
-    Remove-TeamDrive -TeamDriveId "0AJ8Xjq3FcdCKUk9PVA" -Confirm:$false
+    Remove-Drive -DriveId "0AJ8Xjq3FcdCKUk9PVA" -Confirm:$false
 
-    Removes the Team Drive '0AJ8Xjq3FcdCKUk9PVA', skipping confirmation
+    Removes the Shared Drive '0AJ8Xjq3FcdCKUk9PVA', skipping confirmation
     #>
     [cmdletbinding(SupportsShouldProcess=$true,ConfirmImpact="High")]
     Param
     (
         [parameter(Mandatory = $true,ValueFromPipelineByPropertyName = $true)]
-        [Alias('Id')]
+        [Alias('Id','TeamDriveId')]
         [String[]]
-        $TeamDriveId,
+        $DriveId,
         [parameter(Mandatory = $false,Position = 0,ValueFromPipelineByPropertyName = $true)]
         [Alias('Owner','PrimaryEmail','UserKey','Mail')]
         [string]
@@ -45,12 +45,12 @@ function Remove-GSTeamDrive {
         }
         $service = New-GoogleService @serviceParams
         try {
-            foreach ($id in $TeamDriveId) {
-                if ($PSCmdlet.ShouldProcess("Deleting Team Drive '$id' from user '$User'")) {
-                    Write-Verbose "Deleting Team Drive '$id' from user '$User'"
-                    $request = $service.Teamdrives.Delete($id)
+            foreach ($id in $DriveId) {
+                if ($PSCmdlet.ShouldProcess("Deleting Shared Drive '$id' from user '$User'")) {
+                    Write-Verbose "Deleting Shared Drive '$id' from user '$User'"
+                    $request = $service.Drives.Delete($id)
                     $request.Execute()
-                    Write-Verbose "Team Drive '$id' successfully deleted from user '$User'"
+                    Write-Verbose "Shared Drive '$id' successfully deleted from user '$User'"
                 }
             }
         }

--- a/PSGSuite/Public/Drive/Show-GSDrive.ps1
+++ b/PSGSuite/Public/Drive/Show-GSDrive.ps1
@@ -1,0 +1,64 @@
+function Show-GSDrive {
+    <#
+    .SYNOPSIS
+    Shows (unhides) a Shared Drive in the default view
+
+    .DESCRIPTION
+    Shows (unhides) a Shared Drive in the default view
+
+    .PARAMETER DriveId
+    The unique Id of the Shared Drive to unhide
+
+    .PARAMETER User
+    The email or unique Id of the user who you'd like to unhide the Shared Drive for.
+
+    Defaults to the AdminEmail user.
+
+    .EXAMPLE
+    Show-GSDrive -DriveId $driveIds
+
+    Unhides the specified DriveIds for the AdminEmail user
+    #>
+    [OutputType('Google.Apis.Drive.v3.Data.Drive')]
+    [cmdletbinding()]
+    Param
+    (
+        [parameter(Mandatory = $true,ValueFromPipelineByPropertyName = $true,ParameterSetName = "Get")]
+        [Alias('Id','TeamDriveId')]
+        [String[]]
+        $DriveId,
+        [parameter(Mandatory = $false,Position = 0,ValueFromPipelineByPropertyName = $true)]
+        [Alias('Owner','PrimaryEmail','UserKey','Mail')]
+        [string]
+        $User = $Script:PSGSuite.AdminEmail
+    )
+    Process {
+        if ($User -ceq 'me') {
+            $User = $Script:PSGSuite.AdminEmail
+        }
+        elseif ($User -notlike "*@*.*") {
+            $User = "$($User)@$($Script:PSGSuite.Domain)"
+        }
+        $serviceParams = @{
+            Scope       = 'https://www.googleapis.com/auth/drive'
+            ServiceType = 'Google.Apis.Drive.v3.DriveService'
+            User        = $User
+        }
+        $service = New-GoogleService @serviceParams
+        foreach ($id in $DriveId) {
+            try {
+                $request = $service.Drives.Unhide($id)
+                Write-Verbose "Unhiding Shared Drive '$id' for user '$User'"
+                $request.Execute() | Add-Member -MemberType NoteProperty -Name 'User' -Value $User -PassThru
+            }
+            catch {
+                if ($ErrorActionPreference -eq 'Stop') {
+                    $PSCmdlet.ThrowTerminatingError($_)
+                }
+                else {
+                    Write-Error $_
+                }
+            }
+        }
+    }
+}

--- a/PSGSuite/Public/Drive/Update-GSDrive.ps1
+++ b/PSGSuite/Public/Drive/Update-GSDrive.ps1
@@ -1,74 +1,75 @@
-function Update-GSTeamDrive {
+function Update-GSDrive {
     <#
     .SYNOPSIS
-    Update metatdata for a Team Drive
+    Update metatdata for a Shared Drive
 
     .DESCRIPTION
-    Update metatdata for a Team Drive
+    Update metatdata for a Shared Drive
 
-    .PARAMETER TeamDriveId
-    The unique Id of the Team Drive to update
+    .PARAMETER DriveId
+    The unique Id of the Shared Drive to update
 
     .PARAMETER User
-    The user to create the Team Drive for (must have permissions to create Team Drives)
+    The user to create the Shared Drive for (must have permissions to create Shared Drives)
 
     .PARAMETER Name
-    The name of the Team Drive
+    The name of the Shared Drive
 
     .PARAMETER CanAddChildren
-    Whether the current user can add children to folders in this Team Drive
+    Whether the current user can add children to folders in this Shared Drive
 
-    .PARAMETER CanChangeTeamDriveBackground
-    Whether the current user can change the background of this Team Drive
+    .PARAMETER CanChangeDriveBackground
+    Whether the current user can change the background of this Shared Drive
 
     .PARAMETER CanComment
-    Whether the current user can comment on files in this Team Drive
+    Whether the current user can comment on files in this Shared Drive
 
     .PARAMETER CanCopy
-    Whether the current user can copy files in this Team Drive
+    Whether the current user can copy files in this Shared Drive
 
-    .PARAMETER CanDeleteTeamDrive
-    Whether the current user can delete this Team Drive. Attempting to delete the Team Drive may still fail if there are untrashed items inside the Team Drive
+    .PARAMETER CanDeleteDrive
+    Whether the current user can delete this Shared Drive. Attempting to delete the Shared Drive may still fail if there are untrashed items inside the Shared Drive
 
     .PARAMETER CanDownload
-    Whether the current user can download files in this Team Drive
+    Whether the current user can download files in this Shared Drive
 
     .PARAMETER CanEdit
-    Whether the current user can edit files in this Team Drive
+    Whether the current user can edit files in this Shared Drive
 
     .PARAMETER CanListChildren
-    Whether the current user can list the children of folders in this Team Drive
+    Whether the current user can list the children of folders in this Shared Drive
 
     .PARAMETER CanManageMembers
-    Whether the current user can add members to this Team Drive or remove them or change their role
+    Whether the current user can add members to this Shared Drive or remove them or change their role
 
     .PARAMETER CanReadRevisions
-    Whether the current user can read the revisions resource of files in this Team Drive
+    Whether the current user can read the revisions resource of files in this Shared Drive
 
     .PARAMETER CanRemoveChildren
-    Whether the current user can remove children from folders in this Team Drive
+    Whether the current user can remove children from folders in this Shared Drive
 
     .PARAMETER CanRename
-    Whether the current user can rename files or folders in this Team Drive
+    Whether the current user can rename files or folders in this Shared Drive
 
-    .PARAMETER CanRenameTeamDrive
-    Whether the current user can rename this Team Drive
+    .PARAMETER CanRenameDrive
+    Whether the current user can rename this Shared Drive
 
     .PARAMETER CanShare
-    Whether the current user can share files or folders in this Team Drive
+    Whether the current user can share files or folders in this Shared Drive
 
     .EXAMPLE
-    Update-GSTeamDrive -TeamDriveId '0AJ8Xjq3FcdCKUk9PVA' -Name "HR Document Repo"
+    Update-GSDrive -DriveId '0AJ8Xjq3FcdCKUk9PVA' -Name "HR Document Repo"
 
-    Updated the Team Drive with a new name, "HR Document Repo"
+    Updated the Shared Drive with a new name, "HR Document Repo"
     #>
-    [OutputType('Google.Apis.Drive.v3.Data.TeamDrive')]
+    [OutputType('Google.Apis.Drive.v3.Data.Drive')]
     [cmdletbinding()]
     Param
     (
         [parameter(Mandatory = $true,Position = 0)]
+        [Alias('Id','TeamDriveId')]
         [String]
-        $TeamDriveId,
+        $DriveId,
         [parameter(Mandatory = $false,Position = 0,ValueFromPipelineByPropertyName = $true)]
         [Alias('Owner','PrimaryEmail','UserKey','Mail')]
         [string]
@@ -80,8 +81,9 @@ function Update-GSTeamDrive {
         [Switch]
         $CanAddChildren,
         [parameter(Mandatory = $false)]
+        [Alias('CanChangeTeamDriveBackground')]
         [Switch]
-        $CanChangeTeamDriveBackground,
+        $CanChangeDriveBackground,
         [parameter(Mandatory = $false)]
         [Switch]
         $CanComment,
@@ -89,8 +91,9 @@ function Update-GSTeamDrive {
         [Switch]
         $CanCopy,
         [parameter(Mandatory = $false)]
+        [Alias('CanDeleteTeamDrive')]
         [Switch]
-        $CanDeleteTeamDrive,
+        $CanDeleteDrive,
         [parameter(Mandatory = $false)]
         [Switch]
         $CanDownload,
@@ -113,8 +116,9 @@ function Update-GSTeamDrive {
         [Switch]
         $CanRename,
         [parameter(Mandatory = $false)]
+        [Alias('CanRenameTeamDrive')]
         [Switch]
-        $CanRenameTeamDrive,
+        $CanRenameDrive,
         [parameter(Mandatory = $false)]
         [Switch]
         $CanShare
@@ -133,8 +137,8 @@ function Update-GSTeamDrive {
         }
         $service = New-GoogleService @serviceParams
         try {
-            $body = New-Object 'Google.Apis.Drive.v3.Data.TeamDrive'
-            $capabilities = New-Object 'Google.Apis.Drive.v3.Data.TeamDrive+CapabilitiesData'
+            $body = New-Object 'Google.Apis.Drive.v3.Data.Drive'
+            $capabilities = New-Object 'Google.Apis.Drive.v3.Data.Drive+CapabilitiesData'
             foreach ($key in $PSBoundParameters.Keys) {
                 switch ($key) {
                     Default {
@@ -148,8 +152,8 @@ function Update-GSTeamDrive {
                 }
             }
             $body.Capabilities = $capabilities
-            $request = $service.Teamdrives.Update($body,$TeamDriveId)
-            Write-Verbose "Updating Team Drive '$Name' for user '$User'"
+            $request = $service.Drives.Update($body,$DriveId)
+            Write-Verbose "Updating Shared Drive '$Name' for user '$User'"
             $request.Execute() | Add-Member -MemberType NoteProperty -Name 'User' -Value $User -PassThru
         }
         catch {

--- a/PSGSuite/Public/Groups/Update-GSGroupSettings.ps1
+++ b/PSGSuite/Public/Groups/Update-GSGroupSettings.ps1
@@ -39,6 +39,9 @@ function Update-GSGroupSettings {
     .PARAMETER Email
     Email id of the group
 
+    .PARAMETER EnableCollaborativeInbox
+    Specifies whether the collaborative inbox functionality will be turned on or off for the group.
+
     .PARAMETER IncludeCustomFooter
     Whether to include custom footer
 
@@ -112,6 +115,13 @@ function Update-GSGroupSettings {
     * "ALL_IN_DOMAIN_CAN_CONTACT"
     * "ALL_MEMBERS_CAN_CONTACT"
     * "ALL_MANAGERS_CAN_CONTACT"
+
+    .PARAMETER WhoCanDiscoverGroup
+    Specifies the set of users for whom this group is discoverable.
+    Available values are:
+    * "ANYONE_CAN_DISCOVER"
+    * "ALL_IN_DOMAIN_CAN_DISCOVER"
+    * "ALL_MEMBERS_CAN_DISCOVER"
 
     .PARAMETER WhoCanInvite
     Permissions to invite members.
@@ -212,6 +222,9 @@ function Update-GSGroupSettings {
         $Email,
         [parameter(Mandatory = $false)]
         [Switch]
+        $EnableCollaborativeInbox,
+        [parameter(Mandatory = $false)]
+        [Switch]
         $IncludeCustomFooter,
         [parameter(Mandatory = $false)]
         [Switch]
@@ -255,6 +268,10 @@ function Update-GSGroupSettings {
         [ValidateSet("ALL_IN_DOMAIN_CAN_CONTACT","ALL_MANAGERS_CAN_CONTACT","ALL_MEMBERS_CAN_CONTACT","ANYONE_CAN_CONTACT")]
         [String]
         $WhoCanContactOwner,
+        [parameter(Mandatory = $false)]
+        [ValidateSet("ANYONE_CAN_DISCOVER","ALL_IN_DOMAIN_CAN_DISCOVER","ALL_MEMBERS_CAN_DISCOVER")]
+        [String]
+        $WhoCanDiscoverGroup,
         [parameter(Mandatory = $false)]
         [ValidateSet("ALL_MANAGERS_CAN_INVITE","ALL_MEMBERS_CAN_INVITE","NONE_CAN_INVITE")]
         [String]

--- a/README.md
+++ b/README.md
@@ -158,7 +158,19 @@ All other functions are either intact or have an alias included to support backw
 
 [Full CHANGELOG here](https://github.com/scrthq/PSGSuite/blob/master/CHANGELOG.md)
 
-#### 2.28.2
+#### 2.29.0
+
+* [Issue #201](https://github.com/scrthq/PSGSuite/issues/201)
+  * Fixed: Fields parameter on remaining `*-GSDriveFile` functions
+* [Issue #197](https://github.com/scrthq/PSGSuite/issues/197)
+  * Updated: All remaining `*-TeamDrive` functions now use the new Drives namespace. All previous functions names have been converted to aliases to maintain backwards compatibility.
+  * Added: `Hide-GSDrive`
+  * Added: `Show-GSDrive`
+* [Issue #184](https://github.com/scrthq/PSGSuite/issues/184)
+  * Added: `EnableCollaborativeInbox` parameter to `Update-GSGroupSettings`
+  * Added: `WhoCanDiscoverGroup` parameter to `Update-GSGroupSettings`
+
+## 2.28.2
 
 * [Issue #194](https://github.com/scrthq/PSGSuite/issues/194)
   * Fixed: Parameters not setting correctyl on `Update-GSChromeOSDevice`:
@@ -166,63 +178,3 @@ All other functions are either intact or have an alias included to support backw
     * `AnnotatedLocation [string]`
     * `AnnotatedUser [string]`
     * `Notes [string]`
-
-#### 2.28.1
-
-* [Issue #188](https://github.com/scrthq/PSGSuite/issues/188)
-  * Fixed: `Get-SafeFileName` correctly replaces special RegEx chars with underscores as well.
-
-#### 2.28.0
-
-* [Issue #188](https://github.com/scrthq/PSGSuite/issues/188)
-  * Added: `Get-GSDriveFile` now supports specifying a full file path.
-  * Fixed: `Get-GSDriveFile` will now replace any special path characters in the filename with underscores
-  * Added: The File object returned by `Get-GSDriveFile` will now include an additional `OutFilePath` property if the file is downloaded. This property will contain the full path to the downloaded file.
-* [Issue #190](https://github.com/scrthq/PSGSuite/issues/190)
-  * Fixed: `Fields` parameter on `Get-GSDriveFile` and `Update-GSDriveFile` were not being honored.
-* [Issue #192](https://github.com/scrthq/PSGSuite/issues/192)
-  * Added: Parameters to `Update-GSDriveFile`:
-    * `CopyRequiresWriterPermission [switch]`
-    * `Starred [switch]`
-    * `Trashed [switch]`
-    * `WritersCanShare [switch]`
-* [Issue #194](https://github.com/scrthq/PSGSuite/issues/194)
-  * Added: Parameters to `Update-GSChromeOSDevice`:
-    * `AnnotatedAssetId [string]`
-    * `AnnotatedLocation [string]`
-    * `AnnotatedUser [string]`
-    * `Notes [string]`
-* [Issue #195](https://github.com/scrthq/PSGSuite/issues/195)
-  * Added: `Limit` parameter with `First` alias to the following `List` functions:
-    * `Get-GSActivityReport`
-    * `Get-GSAdminRole`
-    * `Get-GSAdminRoleAssignment`
-    * `Get-GSCalendar`
-    * `Get-GSCalendarAcl`
-    * `Get-GSCalendarEvent`
-    * `Get-GSChromeOSDevice`
-    * `Get-GSDataTransferApplication`
-    * `Get-GSDrive`
-    * `Get-GSDriveFileList`
-    * `Get-GSDrivePermission`
-    * `Get-GSGmailMessageList`
-    * `Get-GSGroup`
-    * `Get-GSGroupMember`
-    * `Get-GSMobileDevice`
-    * `Get-GSResource`
-    * `Get-GSTask`
-    * `Get-GSTaskList`
-    * `Get-GSUsageReport`
-    * `Get-GSUser`
-    * `Get-GSUserLicense`
-* [Issue #196](https://github.com/scrthq/PSGSuite/issues/196)
-  * Fixed: `Get-GSTeamDrive` was not paginating through the results.
-* [Issue #197](https://github.com/scrthq/PSGSuite/issues/197)
-  * Renamed: `Get-GSTeamDrive` has been changed to `Get-GSDrive`. `Get-GSTeamDrive` has been turned into an alias for `Get-GSDrive` to maintain backwards compatibility.
-  * Replaced: `SupportsTeamDrives = $true` with `SupportsAllDrives = $true` on all functions that have it.
-* Miscellaneous
-  * Fixed: `Export-PSGSuiteConfig` is faster due to safely assuming that the P12Key and/or ClientSecrets values have already been pulled from the corresponding keys.
-  * Fixed: Incomplete documentation for `Test-GSGroupMembership`.
-  * Added: `UseDomainAdminAccess` switch parameter to `Get-GSTeamDrive`
-  * Removed: `Get-GSUserLicenseListPrivate` by rolling the `List` code into `Get-GSUserLicense`
-  * Removed: `Get-GSResourceListPrivate` by rolling the `List` code into `Get-GSResource`

--- a/README.md
+++ b/README.md
@@ -169,12 +169,3 @@ All other functions are either intact or have an alias included to support backw
 * [Issue #184](https://github.com/scrthq/PSGSuite/issues/184)
   * Added: `EnableCollaborativeInbox` parameter to `Update-GSGroupSettings`
   * Added: `WhoCanDiscoverGroup` parameter to `Update-GSGroupSettings`
-
-## 2.28.2
-
-* [Issue #194](https://github.com/scrthq/PSGSuite/issues/194)
-  * Fixed: Parameters not setting correctyl on `Update-GSChromeOSDevice`:
-    * `AnnotatedAssetId [string]`
-    * `AnnotatedLocation [string]`
-    * `AnnotatedUser [string]`
-    * `Notes [string]`


### PR DESCRIPTION
## 2.29.0

* [Issue #201](https://github.com/scrthq/PSGSuite/issues/201)
  * Fixed: Fields parameter on remaining `*-GSDriveFile` functions
* [Issue #197](https://github.com/scrthq/PSGSuite/issues/197)
  * Updated: All remaining `*-TeamDrive` functions now use the new Drives namespace. All previous functions names have been converted to aliases to maintain backwards compatibility.
  * Added: `Hide-GSDrive`
  * Added: `Show-GSDrive`
* [Issue #184](https://github.com/scrthq/PSGSuite/issues/184)
  * Added: `EnableCollaborativeInbox` parameter to `Update-GSGroupSettings`
  * Added: `WhoCanDiscoverGroup` parameter to `Update-GSGroupSettings`