### PR TITLE
Multiple fixes and features to add

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 * [PSGSuite - ChangeLog](#PSGSuite---ChangeLog)
+  * [2.30.0](#2300)
   * [2.29.0](#2290)
   * [2.28.2](#2282)
   * [2.28.1](#2281)
@@ -90,6 +91,25 @@
 ***
 
 # PSGSuite - ChangeLog
+
+## 2.30.0
+
+* [Issue #193](https://github.com/scrthq/PSGSuite/issues/193)
+  * Added: Drive Revision functions:
+    * `Get-GSDriveRevision`
+    * `Remove-GSDriveRevision`
+    * `Update-GSDriveRevision`
+* [Issue #210](https://github.com/scrthq/PSGSuite/issues/210)
+  * Fixed: `Update-GSUser` was not accepting User ID's as the User parameter
+* [Issue #209](https://github.com/scrthq/PSGSuite/issues/209)
+  * Added: Support for inline image downloading with `Get-GSGmailMessage` where the image is not included on the Attachments property of the parsed message object.
+  * Fixed: `Get-GSGmailMessage` will now automatically set the `Format` to `Raw` if either `ParseMessage` or `SaveAttachmentsTo` is passed, as `ParseMessage` is a requirement in order to be able to access the message attachments as needed.
+* [Issue #204](https://github.com/scrthq/PSGSuite/issues/204)
+  * Added: `Recurse` parameter to `Get-GSDriveFileList` to allow recursively listing all files and subfolders underneath the result set. Confirmed setting the `Limit` parameter also works as expected with `Recurse` included, stopping is the original limit is reached.
+  * Added: `Get-GSDriveFolderSize` function to return the calculated total size of the files in the specified folder(s).
+* Miscellaneous
+  * Added: `Rfc822MsgId` parameter to `Get-GSGmailMessageList` to easily build a query looking for a specific RFS 822 Message ID.
+  * Added: Pipeline support for `*-GSDrivePermission` functions to enable piping Drive Files into them to manage permissions without looping manually.
 
 ## 2.29.0
 

--- a/PSGSuite/PSGSuite.psd1
+++ b/PSGSuite/PSGSuite.psd1
@@ -12,7 +12,7 @@
     RootModule            = 'PSGSuite.psm1'
 
     # Version number of this module.
-    ModuleVersion         = '2.29.0'
+    ModuleVersion         = '2.30.0'
 
     # ID used to uniquely identify this module
     GUID                  = '9d751152-e83e-40bb-a6db-4c329092aaec'

--- a/PSGSuite/Public/Drive/Add-GSDrivePermission.ps1
+++ b/PSGSuite/Public/Drive/Add-GSDrivePermission.ps1
@@ -78,11 +78,8 @@ function Add-GSDrivePermission {
     [cmdletbinding(SupportsShouldProcess = $true,ConfirmImpact = "High",DefaultParameterSetName = "Email")]
     Param
     (
-        [parameter(Mandatory = $false,Position = 0,ValueFromPipelineByPropertyName = $true)]
-        [Alias('Owner','PrimaryEmail','UserKey','Mail')]
-        [string]
-        $User = $Script:PSGSuite.AdminEmail,
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory = $true,Position = 0,ValueFromPipelineByPropertyName = $true)]
+        [Alias('Id')]
         [String]
         $FileId,
         [parameter(Mandatory = $true)]
@@ -93,6 +90,10 @@ function Add-GSDrivePermission {
         [ValidateSet("User","Group","Domain","Anyone")]
         [String]
         $Type,
+        [parameter(Mandatory = $false,Position = 1,ValueFromPipelineByPropertyName = $true)]
+        [Alias('Owner','PrimaryEmail','UserKey','Mail')]
+        [string]
+        $User = $Script:PSGSuite.AdminEmail,
         [parameter(Mandatory = $false,ParameterSetName = "Email")]
         [String]
         $EmailAddress,

--- a/PSGSuite/Public/Drive/Get-GSDriveFolderSize.ps1
+++ b/PSGSuite/Public/Drive/Get-GSDriveFolderSize.ps1
@@ -1,0 +1,63 @@
+function Get-GSDriveFolderSize {
+    <#
+    .SYNOPSIS
+    Gets the size of the files with the specified ParentFolderId in Drive.
+
+    .DESCRIPTION
+    Gets the size of the files with the specified ParentFolderId in Drive.
+
+    .PARAMETER ParentFolderId
+    ID of parent folder to search to add to the filter
+
+    .PARAMETER Recurse
+    If True, recurses through subfolders found underneath primary search results
+
+    .PARAMETER Depth
+    Internal use only. Used to track how deep in the subfolder structure the command is currently searching when used with -Verbose
+
+    .EXAMPLE
+    Get-GSDriveFolderSize -ParentFolderId $id1,$id2 -Recurse
+    #>
+
+    [CmdletBinding()]
+    Param (
+        [parameter(Mandatory,Position = 0,ValueFromPipelineByPropertyName)]
+        [Alias('Id')]
+        [String[]]
+        $ParentFolderId,
+        [parameter()]
+        [Switch]
+        $Recurse,
+        [parameter()]
+        [Int]
+        $Depth = 0
+    )
+    Begin {
+        $final = @{
+            TotalSize = 0
+        }
+    }
+    Process {
+        foreach ($id in $ParentFolderId) {
+            $files = Get-GSDriveFileList -ParentFolderId $id -IncludeTeamDriveItems -Fields "files(name, id, size, mimeType)" -Verbose:$false
+            $folderTotal = ($files.Size | Measure-Object -Sum).Sum
+            if ($folderTotal){
+                Write-Verbose ("Total file size in bytes in folder ID '$id': {0}" -f $folderTotal)
+                $final.TotalSize +=  $folderTotal
+            }
+            if ($Recurse -and ($subfolders = $files | Where-Object {$_.MimeType -eq 'application/vnd.google-apps.folder'})) {
+                $newDepth = $Depth + 1
+                Write-Verbose "[Depth: $Depth > $newDepth] Recursively searching subfolder Ids: [ $($subfolders.Id -join ", ") ]"
+                $subFolderTotal = Get-GSDriveFolderSize -ParentFolderId $subfolders.Id -Recurse -Depth $newDepth
+                if ($subFolderTotal) {
+                    $final.TotalSize += $subFolderTotal.TotalSize
+                }
+            }
+        }
+    }
+    End {
+        $final['TotalSizeInMB'] = $final['TotalSize'] / 1MB
+        $final['TotalSizeInGB'] = $final['TotalSize'] / 1GB
+        [PSCustomObject]$final
+    }
+}

--- a/PSGSuite/Public/Drive/Get-GSDrivePermission.ps1
+++ b/PSGSuite/Public/Drive/Get-GSDrivePermission.ps1
@@ -32,13 +32,14 @@ function Get-GSDrivePermission {
     [cmdletbinding(DefaultParameterSetName = "List")]
     Param
     (
-        [parameter(Mandatory = $false,Position = 0,ValueFromPipelineByPropertyName = $true)]
+        [parameter(Mandatory = $true,Position = 0,ValueFromPipelineByPropertyName = $true)]
+        [Alias('Id')]
+        [String]
+        $FileId,
+        [parameter(Mandatory = $false,Position = 1,ValueFromPipelineByPropertyName = $true)]
         [Alias('Owner','PrimaryEmail','UserKey','Mail')]
         [string]
         $User = $Script:PSGSuite.AdminEmail,
-        [parameter(Mandatory = $true)]
-        [String]
-        $FileId,
         [parameter(Mandatory = $false,ParameterSetName = "Get")]
         [String[]]
         $PermissionId,

--- a/PSGSuite/Public/Drive/Get-GSDriveRevision.ps1
+++ b/PSGSuite/Public/Drive/Get-GSDriveRevision.ps1
@@ -1,0 +1,207 @@
+function Get-GSDriveRevision {
+    <#
+    .SYNOPSIS
+    Gets information about a Drive file's revisions
+
+    .DESCRIPTION
+    Gets information about a Drive file's revisions
+
+    .PARAMETER FileId
+    The unique Id of the file to get revisions of
+
+    .PARAMETER RevisionId
+    The unique Id of the revision to get. If excluded, gets the list of revisions for the file
+
+    .PARAMETER User
+    The email or unique Id of the owner of the Drive file
+
+    Defaults to the AdminEmail user
+
+    .PARAMETER Fields
+    The specific fields to returned
+
+    .EXAMPLE
+    Get-GSDriveFile -FileId '1rhsAYTOB_vrpvfwImPmWy0TcVa2sgmQa_9u976'
+
+    Gets the information for the file
+
+    .EXAMPLE
+    Get-GSDriveFile -FileId '1rhsAYTOB_vrpvfwImPmWy0TcVa2sgmQa_9u976' -OutFilePath (Get-Location).Path
+
+    Gets the information for the file and saves the file in the current working directory
+    #>
+    [OutputType('Google.Apis.Drive.v3.Data.Revision')]
+    [cmdletbinding(DefaultParameterSetName = "List")]
+    Param
+    (
+        [parameter(Mandatory = $true,Position = 0,ValueFromPipelineByPropertyName = $true)]
+        [Alias('Id')]
+        [String]
+        $FileId,
+        [parameter(Mandatory = $false,Position = 1,ParameterSetName = "Get")]
+        [String[]]
+        $RevisionId,
+        [parameter(Mandatory = $false,ParameterSetName = "Get")]
+        [Alias('SaveFileTo')]
+        [String]
+        $OutFilePath,
+        [parameter(Mandatory = $false,ValueFromPipelineByPropertyName = $true)]
+        [Alias('Owner','PrimaryEmail','UserKey','Mail')]
+        [string]
+        $User = $Script:PSGSuite.AdminEmail,
+        [parameter(Mandatory = $false,ParameterSetName = "Fields")]
+        [String[]]
+        $Fields,
+        [parameter(Mandatory = $false,ParameterSetName = "Get")]
+        [Switch]
+        $Force,
+        [parameter(Mandatory = $false,ParameterSetName = "List")]
+        [Alias('MaxResults')]
+        [ValidateRange(1,1000)]
+        [Int]
+        $PageSize = 1000,
+        [parameter(Mandatory = $false,ParameterSetName = "List")]
+        [Alias('First')]
+        [Int]
+        $Limit = 0
+    )
+    Process {
+        if ($User -ceq 'me') {
+            $User = $Script:PSGSuite.AdminEmail
+        }
+        elseif ($User -notlike "*@*.*") {
+            $User = "$($User)@$($Script:PSGSuite.Domain)"
+        }
+        $serviceParams = @{
+            Scope       = 'https://www.googleapis.com/auth/drive'
+            ServiceType = 'Google.Apis.Drive.v3.DriveService'
+            User        = $User
+        }
+        $service = New-GoogleService @serviceParams
+        switch ($PSCmdlet.ParameterSetName) {
+            Get {
+                try {
+                    foreach ($revision in $RevisionId) {
+                        $request = $service.Revisions.Get($FileId,$revision)
+                        if ($Fields) {
+                            $request.Fields = $($Fields -join ",")
+                        }
+                        $baseVerbose = "Getting"
+                        if ($Fields) {
+                            $baseVerbose += " Fields [$($Fields -join ",")] of"
+                        }
+                        $baseVerbose += " Drive File Revision Id '$revision' of File Id '$FileId' for User '$User'"
+                        Write-Verbose $baseVerbose
+                        $res = $request.Execute() | Add-Member -MemberType NoteProperty -Name 'User' -Value $User -PassThru | Add-Member -MemberType NoteProperty -Name 'FileId' -Value $FileId -PassThru
+                        if ($OutFilePath) {
+                            if (Test-Path $OutFilePath) {
+                                $outFilePathItem = Get-Item $OutFilePath -ErrorAction SilentlyContinue
+                                if ($outFilePathItem.PSIsContainer) {
+                                    $resPath = $outFilePathItem.FullName
+                                    $cleanedName = Get-SafeFileName "$($res.Name).$($res.FileExtension)"
+                                    $filePath = Join-Path $resPath $cleanedName
+                                }
+                                elseif ($Force) {
+                                    $endings = [System.Collections.Generic.List[string]]@('.bak')
+                                    1..100 | ForEach-Object {$endings.Add(".bak$_")}
+                                    foreach ($end in $endings) {
+                                        $backupPath = "$($outFilePathItem.FullName)$end"
+                                        if (-not (Test-Path $backupPath)) {
+                                            break
+                                        }
+                                        else {
+                                            $backupPath = $null
+                                        }
+                                    }
+                                    Write-Warning "Renaming '$($outFilePathItem.Name)' to '$($outFilePathItem.Name).bak' in case replacement download fails."
+                                    Rename-Item $outFilePathItem.FullName -NewName $backupPath -Force
+                                    $filePath = $OutFilePath
+                                }
+                                else {
+                                    throw "File already exists at path '$($OutFilePath)'. Please specify -Force to overwrite any files with the same name if they exist."
+                                }
+                            }
+                            else {
+                                $filePath = $OutFilePath
+                            }
+                            Write-Verbose "Saving file to path '$filePath'"
+                            $stream = [System.IO.File]::Create($filePath)
+                            $request.Download($stream)
+                            $stream.Close()
+                            $res | Add-Member -MemberType NoteProperty -Name OutFilePath -Value $filePath -Force
+                            if ($backupPath) {
+                                Write-Verbose "File has been downloaded successfully! Removing the backup file at path: $backupPath"
+                                Remove-Item $backupPath -Recurse -Force -Confirm:$false
+                            }
+                        }
+                        $res
+                    }
+                }
+                catch {
+                    $err = $_
+                    if ($backupPath) {
+                        if (Test-Path $outFilePathItem.FullName) {
+                            Remove-Item $outFilePathItem.FullName -Recurse -Force
+                        }
+                        Rename-Item $backupPath -NewName $outFilePathItem.FullName -Force
+                    }
+                    if ($ErrorActionPreference -eq 'Stop') {
+                        $PSCmdlet.ThrowTerminatingError($err)
+                    }
+                    else {
+                        Write-Error $err
+                    }
+                }
+            }
+            List {
+                try {
+                    $request = $service.Revisions.List($FileId)
+                    if ($Limit -gt 0 -and $PageSize -gt $Limit) {
+                        Write-Verbose ("Reducing PageSize from {0} to {1} to meet limit with first page" -f $PageSize,$Limit)
+                        $PageSize = $Limit
+                    }
+                    $request.PageSize = $PageSize
+                    if ($Fields) {
+                        $request.Fields = "$($Fields -join ",")"
+                    }
+                    $baseVerbose = "Getting"
+                    if ($Fields) {
+                        $baseVerbose += " Fields [$($Fields -join ",")] of"
+                    }
+                    $baseVerbose += " all Drive File Revisions of File Id '$FileId' for User '$User'"
+                    Write-Verbose $baseVerbose
+                    [int]$i = 1
+                    $overLimit = $false
+                    do {
+                        $result = $request.Execute()
+                        $result.Revisions | Add-Member -MemberType NoteProperty -Name 'User' -Value $User -PassThru | Add-Member -MemberType NoteProperty -Name 'FileId' -Value $FileId -PassThru
+                        if ($result.NextPageToken) {
+                            $request.PageToken = $result.NextPageToken
+                        }
+                        [int]$retrieved = ($i + $result.Revisions.Count) - 1
+                        Write-Verbose "Retrieved $retrieved Revisions..."
+                        if ($Limit -gt 0 -and $retrieved -eq $Limit) {
+                            Write-Verbose "Limit reached: $Limit"
+                            $overLimit = $true
+                        }
+                        elseif ($Limit -gt 0 -and ($retrieved + $PageSize) -gt $Limit) {
+                            $newPS = $Limit - $retrieved
+                            Write-Verbose ("Reducing PageSize from {0} to {1} to meet limit with next page" -f $PageSize,$newPS)
+                            $request.PageSize = $newPS
+                        }
+                        [int]$i = $i + $result.Revisions.Count
+                    }
+                    until ($overLimit -or !$result.NextPageToken)
+                }
+                catch {
+                    if ($ErrorActionPreference -eq 'Stop') {
+                        $PSCmdlet.ThrowTerminatingError($_)
+                    }
+                    else {
+                        Write-Error $_
+                    }
+                }
+            }
+        }
+    }
+}

--- a/PSGSuite/Public/Drive/Get-GSDriveRevision.ps1
+++ b/PSGSuite/Public/Drive/Get-GSDriveRevision.ps1
@@ -21,14 +21,14 @@ function Get-GSDriveRevision {
     The specific fields to returned
 
     .EXAMPLE
-    Get-GSDriveFile -FileId '1rhsAYTOB_vrpvfwImPmWy0TcVa2sgmQa_9u976'
+    Get-GSDriveFile -FileId $fileId | Get-GSDriveRevision
 
-    Gets the information for the file
+    Gets the list of revisions for the file
 
     .EXAMPLE
-    Get-GSDriveFile -FileId '1rhsAYTOB_vrpvfwImPmWy0TcVa2sgmQa_9u976' -OutFilePath (Get-Location).Path
+    Get-GSDriveRevision -FileId $fileId -Limit 1
 
-    Gets the information for the file and saves the file in the current working directory
+    Gets the most recent revision for the file
     #>
     [OutputType('Google.Apis.Drive.v3.Data.Revision')]
     [cmdletbinding(DefaultParameterSetName = "List")]
@@ -49,9 +49,9 @@ function Get-GSDriveRevision {
         [Alias('Owner','PrimaryEmail','UserKey','Mail')]
         [string]
         $User = $Script:PSGSuite.AdminEmail,
-        [parameter(Mandatory = $false,ParameterSetName = "Fields")]
+        [parameter(Mandatory = $false)]
         [String[]]
-        $Fields,
+        $Fields = '*',
         [parameter(Mandatory = $false,ParameterSetName = "Get")]
         [Switch]
         $Force,
@@ -83,12 +83,10 @@ function Get-GSDriveRevision {
                 try {
                     foreach ($revision in $RevisionId) {
                         $request = $service.Revisions.Get($FileId,$revision)
-                        if ($Fields) {
-                            $request.Fields = $($Fields -join ",")
-                        }
                         $baseVerbose = "Getting"
                         if ($Fields) {
                             $baseVerbose += " Fields [$($Fields -join ",")] of"
+                            $request.Fields = $($Fields -join ",")
                         }
                         $baseVerbose += " Drive File Revision Id '$revision' of File Id '$FileId' for User '$User'"
                         Write-Verbose $baseVerbose

--- a/PSGSuite/Public/Drive/Remove-GSDrivePermission.ps1
+++ b/PSGSuite/Public/Drive/Remove-GSDrivePermission.ps1
@@ -30,13 +30,14 @@ function Remove-GSDrivePermission {
     [cmdletbinding(SupportsShouldProcess = $true,ConfirmImpact = "High")]
     Param
     (
-        [parameter(Mandatory = $false,Position = 0,ValueFromPipelineByPropertyName = $true)]
+        [parameter(Mandatory = $true,Position = 0,ValueFromPipelineByPropertyName = $true)]
+        [Alias('Id')]
+        [String]
+        $FileId,
+        [parameter(Mandatory = $false,Position = 1,ValueFromPipelineByPropertyName = $true)]
         [Alias('Owner','PrimaryEmail','UserKey','Mail')]
         [string]
         $User = $Script:PSGSuite.AdminEmail,
-        [parameter(Mandatory = $true,ValueFromPipelineByPropertyName = $true)]
-        [String]
-        $FileId,
         [parameter(Mandatory = $true,ValueFromPipelineByPropertyName = $true)]
         [Alias('Id')]
         [String]

--- a/PSGSuite/Public/Drive/Remove-GSDriveRevision.ps1
+++ b/PSGSuite/Public/Drive/Remove-GSDriveRevision.ps1
@@ -1,0 +1,78 @@
+function Remove-GSDriveRevision {
+    <#
+    .SYNOPSIS
+    Permanently deletes a file version.
+
+    .DESCRIPTION
+    Permanently deletes a file version.
+
+    You can only delete revisions for files with binary content in Google Drive, like images or videos. Revisions for other files, like Google Docs or Sheets, and the last remaining file version can't be deleted.
+
+    .PARAMETER FileId
+    The unique Id of the file to remove revisions from
+
+    .PARAMETER RevisionId
+    The unique Id of the revision to remove
+
+    .PARAMETER User
+    The email or unique Id of the owner of the Drive file
+
+    Defaults to the AdminEmail user
+
+    .EXAMPLE
+    Get-GSDriveRevision -FileId $fileId -Limit 1 | Remove-GSDriveRevision
+
+    Removes the oldest revision for the file
+
+    .EXAMPLE
+    Get-GSDriveRevision -FileId $fileId | Select-Object -Last 1 | Remove-GSDriveRevision
+
+    Removes the newest revision for the file
+    #>
+    [cmdletbinding(SupportsShouldProcess = $true,ConfirmImpact = "High")]
+    Param
+    (
+        [parameter(Mandatory = $true,Position = 0,ValueFromPipelineByPropertyName = $true)]
+        [String]
+        $FileId,
+        [parameter(Mandatory = $true,Position = 1,ValueFromPipelineByPropertyName = $true)]
+        [Alias('Id')]
+        [String[]]
+        $RevisionId,
+        [parameter(Mandatory = $false,ValueFromPipelineByPropertyName = $true)]
+        [Alias('Owner','PrimaryEmail','UserKey','Mail')]
+        [string]
+        $User = $Script:PSGSuite.AdminEmail
+    )
+    Process {
+        if ($User -ceq 'me') {
+            $User = $Script:PSGSuite.AdminEmail
+        }
+        elseif ($User -notlike "*@*.*") {
+            $User = "$($User)@$($Script:PSGSuite.Domain)"
+        }
+        $serviceParams = @{
+            Scope       = 'https://www.googleapis.com/auth/drive'
+            ServiceType = 'Google.Apis.Drive.v3.DriveService'
+            User        = $User
+        }
+        $service = New-GoogleService @serviceParams
+        foreach ($id in $RevisionId) {
+            try {
+                if ($PSCmdlet.ShouldProcess("Removing Drive Revision Id '$id' from FileId '$FileID' for user '$User'")) {
+                    $request = $service.Revisions.Delete($FileId,$id)
+                    $request.Execute()
+                    Write-Verbose "Successfully removed Drive Revision Id '$id' from FileId '$FileID' for user '$User'"
+                }
+            }
+            catch {
+                if ($ErrorActionPreference -eq 'Stop') {
+                    $PSCmdlet.ThrowTerminatingError($_)
+                }
+                else {
+                    Write-Error $_
+                }
+            }
+        }
+    }
+}

--- a/PSGSuite/Public/Drive/Update-GSDriveRevision.ps1
+++ b/PSGSuite/Public/Drive/Update-GSDriveRevision.ps1
@@ -1,0 +1,114 @@
+function Update-GSDriveRevision {
+    <#
+    .SYNOPSIS
+    Updates a revision with patch semantics
+
+    .DESCRIPTION
+    Updates a revision with patch semantics
+
+    .PARAMETER FileId
+    The unique Id of the file to update revisions for
+
+    .PARAMETER RevisionId
+    The unique Id of the revision to update
+
+    .PARAMETER KeepForever
+    Whether to keep this revision forever, even if it is no longer the head revision. If not set, the revision will be automatically purged 30 days after newer content is uploaded. This can be set on a maximum of 200 revisions for a file.
+
+    This field is only applicable to files with binary content in Drive.
+
+    .PARAMETER PublishAuto
+    Whether subsequent revisions will be automatically republished. This is only applicable to Google Docs.
+
+    .PARAMETER Published
+    Whether this revision is published. This is only applicable to Google Docs.
+
+    .PARAMETER PublishedOutsideDomain
+    Whether this revision is published outside the domain. This is only applicable to Google Docs.
+
+    .PARAMETER Fields
+    The specific fields to returned
+
+    .PARAMETER User
+    The email or unique Id of the owner of the Drive file
+
+    Defaults to the AdminEmail user
+
+    .EXAMPLE
+    Get-GSDriveRevision -FileId $fileId -Limit 1 | Update-GSDriveRevision -KeepForever
+
+    Sets 'KeepForever' for the oldest revision of the file to 'True'
+
+    .EXAMPLE
+    Get-GSDriveRevision -FileId $fileId | Select-Object -Last 1 | Update-GSDriveRevision -KeepForever
+
+    Sets 'KeepForever' for the newest revision of the file to 'True'
+    #>
+    [OutputType('Google.Apis.Drive.v3.Data.Revision')]
+    [cmdletbinding()]
+    Param
+    (
+        [parameter(Mandatory = $true,Position = 0,ValueFromPipelineByPropertyName = $true)]
+        [String]
+        $FileId,
+        [parameter(Mandatory = $true,Position = 1,ValueFromPipelineByPropertyName = $true)]
+        [Alias('Id')]
+        [String[]]
+        $RevisionId,
+        [parameter(Mandatory = $false)]
+        [Switch]
+        $KeepForever,
+        [parameter(Mandatory = $false)]
+        [Switch]
+        $PublishAuto,
+        [parameter(Mandatory = $false)]
+        [Switch]
+        $Published,
+        [parameter(Mandatory = $false)]
+        [Switch]
+        $PublishedOutsideDomain,
+        [parameter(Mandatory = $false)]
+        [String[]]
+        $Fields = '*',
+        [parameter(Mandatory = $false,ValueFromPipelineByPropertyName = $true)]
+        [Alias('Owner','PrimaryEmail','UserKey','Mail')]
+        [string]
+        $User = $Script:PSGSuite.AdminEmail
+    )
+    Process {
+        if ($User -ceq 'me') {
+            $User = $Script:PSGSuite.AdminEmail
+        }
+        elseif ($User -notlike "*@*.*") {
+            $User = "$($User)@$($Script:PSGSuite.Domain)"
+        }
+        $serviceParams = @{
+            Scope       = 'https://www.googleapis.com/auth/drive'
+            ServiceType = 'Google.Apis.Drive.v3.DriveService'
+            User        = $User
+        }
+        $service = New-GoogleService @serviceParams
+        $body = New-Object 'Google.Apis.Drive.v3.Data.Revision'
+        foreach ($key in $PSBoundParameters.Keys | Where-Object {$_ -in $body.PSObject.Properties.Name}) {
+            $body.$key = $PSBoundParameters[$key]
+        }
+        foreach ($id in $RevisionId) {
+            try {
+                $request = $service.Revisions.Update($body,$FileId,$id)
+                if ($Fields) {
+                    $request.Fields = $($Fields -join ",")
+                }
+                Write-Verbose "Updating Drive File Revision Id '$revision' of File Id '$FileId' for User '$User'"
+                $request.Execute() | Add-Member -MemberType NoteProperty -Name 'User' -Value $User -PassThru | Add-Member -MemberType NoteProperty -Name 'FileId' -Value $FileId -PassThru
+            }
+            catch {
+                if ($ErrorActionPreference -eq 'Stop') {
+                    $PSCmdlet.ThrowTerminatingError($_)
+                }
+                else {
+                    Write-Error $_
+                }
+            }
+        }
+    }
+}

--- a/PSGSuite/Public/Gmail/Get-GSGmailMessageList.ps1
+++ b/PSGSuite/Public/Gmail/Get-GSGmailMessageList.ps1
@@ -37,17 +37,21 @@ function Get-GSGmailMessageList {
     Gets the list of messages sent directly to the user after 2017/12/25 excluding chats
     #>
     [OutputType('Google.Apis.Gmail.v1.Data.Message')]
-    [cmdletbinding()]
+    [cmdletbinding(DefaultParameterSetName = "Filter")]
     Param
     (
         [parameter(Mandatory = $false,ValueFromPipelineByPropertyName = $true)]
         [Alias("PrimaryEmail","UserKey","Mail")]
         [String]
         $User = $Script:PSGSuite.AdminEmail,
-        [parameter(Mandatory = $false)]
+        [parameter(Mandatory = $false,ParameterSetName = "Filter")]
         [Alias('Query')]
         [String[]]
         $Filter,
+        [parameter(Mandatory = $false,ParameterSetName = "Rfc822MsgId")]
+        [Alias('MessageId','MsgId')]
+        [String]
+        $Rfc822MsgId,
         [parameter(Mandatory = $false)]
         [Alias('LabelId')]
         [String[]]
@@ -93,6 +97,9 @@ function Get-GSGmailMessageList {
                 $request = $service.Users.Messages.List($U)
                 foreach ($key in $PSBoundParameters.Keys) {
                     switch ($key) {
+                        Rfc822MsgId {
+                            $request.Q = "rfc822msgid:$($Rfc822MsgId.Trim())"
+                        }
                         Filter {
                             $request.Q = $($Filter -join " ")
                         }
@@ -111,8 +118,8 @@ function Get-GSGmailMessageList {
                     $PageSize = $Limit
                 }
                 $request.MaxResults = $PageSize
-                if ($Filter) {
-                    Write-Verbose "Getting all Messages matching filter '$Filter' for user '$U'"
+                if ($request.Q) {
+                    Write-Verbose "Getting all Messages matching filter '$($request.Q)' for user '$U'"
                 }
                 else {
                     Write-Verbose "Getting all Messages for user '$U'"

--- a/PSGSuite/Public/Users/Update-GSUser.ps1
+++ b/PSGSuite/Public/Users/Update-GSUser.ps1
@@ -221,12 +221,7 @@ function Update-GSUser {
     Process {
         foreach ($U in $User) {
             try {
-                if ($U -ceq 'me') {
-                    $U = $Script:PSGSuite.AdminEmail
-                }
-                elseif ($U -notlike "*@*.*") {
-                    $U = "$($U)@$($Script:PSGSuite.Domain)"
-                }
+                Resolve-Email ([ref]$U)
                 if ($PSCmdlet.ShouldProcess("Updating user '$U'")) {
                     Write-Verbose "Updating user '$U'"
                     $userObj = Get-GSUser $U -Verbose:$false

--- a/README.md
+++ b/README.md
@@ -158,14 +158,21 @@ All other functions are either intact or have an alias included to support backw
 
 [Full CHANGELOG here](https://github.com/scrthq/PSGSuite/blob/master/CHANGELOG.md)
 
-#### 2.29.0
+#### 2.30.0
 
-* [Issue #201](https://github.com/scrthq/PSGSuite/issues/201)
-  * Fixed: Fields parameter on remaining `*-GSDriveFile` functions
-* [Issue #197](https://github.com/scrthq/PSGSuite/issues/197)
-  * Updated: All remaining `*-TeamDrive` functions now use the new Drives namespace. All previous functions names have been converted to aliases to maintain backwards compatibility.
-  * Added: `Hide-GSDrive`
-  * Added: `Show-GSDrive`
-* [Issue #184](https://github.com/scrthq/PSGSuite/issues/184)
-  * Added: `EnableCollaborativeInbox` parameter to `Update-GSGroupSettings`
-  * Added: `WhoCanDiscoverGroup` parameter to `Update-GSGroupSettings`.
+* [Issue #193](https://github.com/scrthq/PSGSuite/issues/193)
+  * Added: Drive Revision functions:
+    * `Get-GSDriveRevision`
+    * `Remove-GSDriveRevision`
+    * `Update-GSDriveRevision`
+* [Issue #210](https://github.com/scrthq/PSGSuite/issues/210)
+  * Fixed: `Update-GSUser` was not accepting User ID's as the User parameter
+* [Issue #209](https://github.com/scrthq/PSGSuite/issues/209)
+  * Added: Support for inline image downloading with `Get-GSGmailMessage` where the image is not included on the Attachments property of the parsed message object.
+  * Fixed: `Get-GSGmailMessage` will now automatically set the `Format` to `Raw` if either `ParseMessage` or `SaveAttachmentsTo` is passed, as `ParseMessage` is a requirement in order to be able to access the message attachments as needed.
+* [Issue #204](https://github.com/scrthq/PSGSuite/issues/204)
+  * Added: `Recurse` parameter to `Get-GSDriveFileList` to allow recursively listing all files and subfolders underneath the result set. Confirmed setting the `Limit` parameter also works as expected with `Recurse` included, stopping is the original limit is reached.
+  * Added: `Get-GSDriveFolderSize` function to return the calculated total size of the files in the specified folder(s).
+* Miscellaneous
+  * Added: `Rfc822MsgId` parameter to `Get-GSGmailMessageList` to easily build a query looking for a specific RFS 822 Message ID.
+  * Added: Pipeline support for `*-GSDrivePermission` functions to enable piping Drive Files into them to manage permissions without looping manually.

--- a/psake.ps1
+++ b/psake.ps1
@@ -484,7 +484,7 @@ $deployScriptBlock = {
                 if ($ENV:BHBuildSystem -eq 'VSTS' -and -not [String]::IsNullOrEmpty($env:TwitterAccessSecret) -and -not [String]::IsNullOrEmpty($env:TwitterAccessToken) -and -not [String]::IsNullOrEmpty($env:TwitterConsumerKey) -and -not [String]::IsNullOrEmpty($env:TwitterConsumerSecret)) {
                     "    Publishing tweet about new release..."
                     $manifest = Import-PowerShellDataFile -Path (Join-Path $outputModVerDir "$($env:BHProjectName).psd1")
-                    $text = "#$($env:BHProjectName) v$($versionToDeploy) is now available on the #PSGallery! https://www.powershellgallery.com/packages/$($env:BHProjectName) #PowerShell"
+                    $text = "#$($env:BHProjectName) v$($versionToDeploy) is now available on the #PSGallery! https://www.powershellgallery.com/packages/$($env:BHProjectName)/$($versionToDeploy) #PowerShell"
                     $manifest.PrivateData.PSData.Tags | Foreach-Object {
                         $text += " #$($_)"
                     }


### PR DESCRIPTION
## 2.30.0

* [Issue #193](https://github.com/scrthq/PSGSuite/issues/193)
  * Added: Drive Revision functions:
    * `Get-GSDriveRevision`
    * `Remove-GSDriveRevision`
    * `Update-GSDriveRevision`
* [Issue #210](https://github.com/scrthq/PSGSuite/issues/210)
  * Fixed: `Update-GSUser` was not accepting User ID's as the User parameter
* [Issue #209](https://github.com/scrthq/PSGSuite/issues/209)
  * Added: Support for inline image downloading with `Get-GSGmailMessage` where the image is not included on the Attachments property of the parsed message object.
  * Fixed: `Get-GSGmailMessage` will now automatically set the `Format` to `Raw` if either `ParseMessage` or `SaveAttachmentsTo` is passed, as `ParseMessage` is a requirement in order to be able to access the message attachments as needed.
* [Issue #204](https://github.com/scrthq/PSGSuite/issues/204)
  * Added: `Recurse` parameter to `Get-GSDriveFileList` to allow recursively listing all files and subfolders underneath the result set. Confirmed setting the `Limit` parameter also works as expected with `Recurse` included, stopping is the original limit is reached.
  * Added: `Get-GSDriveFolderSize` function to return the calculated total size of the files in the specified folder(s).
* Miscellaneous
  * Added: `Rfc822MsgId` parameter to `Get-GSGmailMessageList` to easily build a query looking for a specific RFS 822 Message ID.
  * Added: Pipeline support for `*-GSDrivePermission` functions to enable piping Drive Files into them to manage permissions without looping manually.