### PR TITLE
Feature/customer domain mgmt and calendar transfer support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,7 +110,8 @@
 * Miscellaneous
   * Added:
     * `Get-GSCustomer`
-    * `Update-GSCustomer` ###
+    * `Update-GSCustomer`
+    * `Add-GSCustomerPostalAddress`
   * _These will need the additional scope of `https://www.googleapis.com/auth/admin.directory.customer` added in order to use!_
 
 ## 2.30.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,15 +97,18 @@
 
 ## 2.31.0
 
+* [Issue #218](https://github.com/scrthq/PSGSuite/issues/218)
+  * Fixed: `Update-GSOrganizationalUnit` was failing with `null` reference errors.
 * [Issue #213](https://github.com/scrthq/PSGSuite/issues/213)
   * Added: Support for `RELEASE_RESOURCES` TransferParam for Calendar application data transfers to function `Start-GSDataTransfer`
 * [Issue #215](https://github.com/scrthq/PSGSuite/issues/215)
   * Added:
-    * `Get-GSDomain` ###
-    * `Remove-GSDomain` ###
-    * `New-GSDomain` ###
-    * `Get-GSDomainAlias` ###
-    * `New-GSDomainAlias` ###
+    * `Get-GSDomain`
+    * `Remove-GSDomain`
+    * `New-GSDomain`
+    * `Get-GSDomainAlias`
+    * `New-GSDomainAlias`
+    * `Remove-GSDomainAlias`
   * _These will need the additional scope of `https://www.googleapis.com/auth/admin.directory.domain` added in order to use!_
 * Miscellaneous
   * Added:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-* [PSGSuite - ChangeLog](#PSGSuite---ChangeLog)
+* [PSGSuite - ChangeLog](#psgsuite---changelog)
+  * [2.31.0](#2310)
   * [2.30.2](#2302)
   * [2.30.1](#2301)
   * [2.30.0](#2300)
@@ -84,15 +85,33 @@
   * [2.0.2](#202)
   * [2.0.1](#201)
   * [2.0.0](#200)
-    * [New Functionality](#New-Functionality)
-    * [Breaking Changes in 2.0.0](#Breaking-Changes-in-200)
-      * [Gmail Delegation Management Removed](#Gmail-Delegation-Management-Removed)
-      * [Functions Removed](#Functions-Removed)
-      * [Functions Aliased](#Functions-Aliased)
+    * [New Functionality](#new-functionality)
+    * [Breaking Changes in 2.0.0](#breaking-changes-in-200)
+      * [Gmail Delegation Management Removed](#gmail-delegation-management-removed)
+      * [Functions Removed](#functions-removed)
+      * [Functions Aliased](#functions-aliased)
 
 ***
 
 # PSGSuite - ChangeLog
+
+## 2.31.0
+
+* [Issue #213](https://github.com/scrthq/PSGSuite/issues/213)
+  * Added: Support for `RELEASE_RESOURCES` TransferParam for Calendar application data transfers to function `Start-GSDataTransfer`
+* [Issue #215](https://github.com/scrthq/PSGSuite/issues/215)
+  * Added:
+    * `Get-GSDomain` ###
+    * `Remove-GSDomain` ###
+    * `New-GSDomain` ###
+    * `Get-GSDomainAlias` ###
+    * `New-GSDomainAlias` ###
+  * _These will need the additional scope of `https://www.googleapis.com/auth/admin.directory.domain` added in order to use!_
+* Miscellaneous
+  * Added:
+    * `Get-GSCustomer`
+    * `Update-GSCustomer` ###
+  * _These will need the additional scope of `https://www.googleapis.com/auth/admin.directory.customer` added in order to use!_
 
 ## 2.30.2
 

--- a/PSGSuite/PSGSuite.psd1
+++ b/PSGSuite/PSGSuite.psd1
@@ -12,7 +12,7 @@
     RootModule            = 'PSGSuite.psm1'
 
     # Version number of this module.
-    ModuleVersion         = '2.30.2'
+    ModuleVersion         = '2.31.0'
 
     # ID used to uniquely identify this module
     GUID                  = '9d751152-e83e-40bb-a6db-4c329092aaec'

--- a/PSGSuite/Public/Customers/Get-GSCustomer.ps1
+++ b/PSGSuite/Public/Customers/Get-GSCustomer.ps1
@@ -18,7 +18,7 @@ function Get-GSCustomer {
         [Parameter(Position = 0,ValueFromPipeline,ValueFromPipelineByPropertyName)]
         [Alias('CustomerId')]
         [String]
-        $CustomerKey
+        $CustomerKey = $Script:PSGSuite.CustomerId
     )
     Begin {
         $serviceParams = @{

--- a/PSGSuite/Public/Customers/Get-GSCustomer.ps1
+++ b/PSGSuite/Public/Customers/Get-GSCustomer.ps1
@@ -1,0 +1,45 @@
+function Get-GSCustomer {
+    <#
+    .SYNOPSIS
+    Retrieves a customer
+
+    .DESCRIPTION
+    Retrieves a customer
+
+    .PARAMETER CustomerKey
+    Id of the Customer to be retrieved
+
+    .EXAMPLE
+    Get-GSCustomer (Get-GSUser).CustomerId
+    #>
+    [OutputType('Google.Apis.Admin.Directory.directory_v1.Data.Customer')]
+    [CmdletBinding()]
+    Param(
+        [Parameter(Position = 0,ValueFromPipeline,ValueFromPipelineByPropertyName)]
+        [Alias('CustomerId')]
+        [String]
+        $CustomerKey
+    )
+    Begin {
+        $serviceParams = @{
+            Scope       = 'https://www.googleapis.com/auth/admin.directory.customer'
+            ServiceType = 'Google.Apis.Admin.Directory.directory_v1.DirectoryService'
+        }
+        $service = New-GoogleService @serviceParams
+    }
+    Process {
+        try {
+            Write-Verbose "Getting Customer '$CustomerKey'"
+            $request = $service.Customers.Get($CustomerKey)
+            $request.Execute()
+        }
+        catch {
+            if ($ErrorActionPreference -eq 'Stop') {
+                $PSCmdlet.ThrowTerminatingError($_)
+            }
+            else {
+                Write-Error $_
+            }
+        }
+    }
+}

--- a/PSGSuite/Public/Customers/Update-GSCustomer.ps1
+++ b/PSGSuite/Public/Customers/Update-GSCustomer.ps1
@@ -1,0 +1,81 @@
+function Update-GSCustomer {
+    <#
+    .SYNOPSIS
+    Updates a customer using patch semantics.
+
+    .DESCRIPTION
+    Updates a customer using patch semantics.
+
+    .PARAMETER CustomerKey
+    Id of the Customer to be updated.
+
+    .PARAMETER AlternateEmail
+    The customer's secondary contact email address. This email address cannot be on the same domain as the customerDomain.
+
+    .PARAMETER CustomerDomain
+    The customer's primary domain name string. Do not include the www prefix when creating a new customer.
+
+    .PARAMETER Language
+    The customer's ISO 639-2 language code. The default value is en-US.
+
+    .PARAMETER PhoneNumber
+    The customer's contact phone number in E.164 format.
+
+    .PARAMETER PostalAddress
+    The customer's postal address information.
+
+    Must be type [Google.Apis.Admin.Directory.directory_v1.Data.CustomerPostalAddress]. Use helper function Add-GSCustomerPostalAddress to create the correct type easily.
+
+    .EXAMPLE
+    Get-GSCustomer (Get-GSUser).CustomerId
+    #>
+    [OutputType('Google.Apis.Admin.Directory.directory_v1.Data.Customer')]
+    [CmdletBinding()]
+    Param(
+        [Parameter(Position = 0,ValueFromPipeline,ValueFromPipelineByPropertyName)]
+        [Alias('CustomerId')]
+        [String]
+        $CustomerKey = $Script:PSGSuite.CustomerId,
+        [Parameter()]
+        [String]
+        $AlternateEmail,
+        [Parameter()]
+        [String]
+        $CustomerDomain,
+        [Parameter()]
+        [String]
+        $Language,
+        [Parameter()]
+        [String]
+        $PhoneNumber,
+        [Parameter()]
+        [Google.Apis.Admin.Directory.directory_v1.Data.CustomerPostalAddress]
+        $PostalAddress
+    )
+    Begin {
+        $serviceParams = @{
+            Scope       = 'https://www.googleapis.com/auth/admin.directory.customer'
+            ServiceType = 'Google.Apis.Admin.Directory.directory_v1.DirectoryService'
+        }
+        $service = New-GoogleService @serviceParams
+    }
+    Process {
+        try {
+            $body = New-Object 'Google.Apis.Admin.Directory.directory_v1.Data.Customer'
+            foreach ($key in $PSBoundParameters.Keys | Where-Object {$body.PSObject.Properties.Name -contains $_}) {
+                $body.$key = $PSBoundParameters[$key]
+            }
+            Write-Verbose "Updating Customer '$CustomerKey'"
+            $request = $service.Customers.Patch($body,$CustomerKey)
+            $request.Execute()
+        }
+        catch {
+            if ($ErrorActionPreference -eq 'Stop') {
+                $PSCmdlet.ThrowTerminatingError($_)
+            }
+            else {
+                Write-Error $_
+            }
+        }
+    }
+}

--- a/PSGSuite/Public/Data Transfer/Start-GSDataTransfer.ps1
+++ b/PSGSuite/Public/Data Transfer/Start-GSDataTransfer.ps1
@@ -18,9 +18,16 @@
     .PARAMETER PrivacyLevel
     The privacy level for the data you'd like to transfer
 
+    *Valid for Drive & Docs data transfers only.*
+
     Available values are:
     * "SHARED": all shared content owned by the user
     * "PRIVATE": all private (unshared) content owned by the user
+
+    .PARAMETER ReleaseResources
+    If true, releases Calendar resources booked by the OldOwner to the NewOwner.
+
+    *Valid for Calendar data transfers only.*
 
     .EXAMPLE
     Start-GSDataTransfer -OldOwnerUserId joe -NewOwnerUserId mark -ApplicationId 55656082996 -PrivacyLevel SHARED,PRIVATE
@@ -40,10 +47,13 @@
         [alias("id")]
         [string]
         $ApplicationId,
-        [parameter(Mandatory=$true)]
+        [parameter(Mandatory=$false)]
         [ValidateSet("SHARED","PRIVATE")]
         [string[]]
-        $PrivacyLevel
+        $PrivacyLevel,
+        [parameter(Mandatory=$false)]
+        [switch]
+        $ReleaseResources
     )
     Begin {
         $serviceParams = @{
@@ -79,6 +89,12 @@
                 $AppDataTransfers.ApplicationTransferParams = [Google.Apis.Admin.DataTransfer.datatransfer_v1.Data.ApplicationTransferParam[]](New-Object 'Google.Apis.Admin.DataTransfer.datatransfer_v1.Data.ApplicationTransferParam' -Property @{
                     Key = 'PRIVACY_LEVEL'
                     Value = [String[]]$PrivacyLevel
+                })
+            }
+            elseif ($ReleaseResources) {
+                $AppDataTransfers.ApplicationTransferParams = [Google.Apis.Admin.DataTransfer.datatransfer_v1.Data.ApplicationTransferParam[]](New-Object 'Google.Apis.Admin.DataTransfer.datatransfer_v1.Data.ApplicationTransferParam' -Property @{
+                    Key = 'RELEASE_RESOURCES'
+                    Value = [String[]]'TRUE'
                 })
             }
             $body.ApplicationDataTransfers = [Google.Apis.Admin.DataTransfer.datatransfer_v1.Data.ApplicationDataTransfer[]]$AppDataTransfers

--- a/PSGSuite/Public/Domains/Get-GSDomain.ps1
+++ b/PSGSuite/Public/Domains/Get-GSDomain.ps1
@@ -1,0 +1,68 @@
+function Get-GSDomain {
+    <#
+    .SYNOPSIS
+    Retrieves a Domain
+
+    .DESCRIPTION
+    Retrieves a Domain
+
+    .PARAMETER DomainName
+    Name of the domain to retrieve.
+
+    If excluded, returns the list of domains.
+
+    .EXAMPLE
+    Get-GSDDomain
+
+    Returns the list of domains.
+    #>
+    [OutputType('Google.Apis.Admin.Directory.directory_v1.Data.Domains')]
+    [CmdletBinding()]
+    Param(
+        [Parameter(Position = 0,ValueFromPipeline,ValueFromPipelineByPropertyName)]
+        [Alias('Domain')]
+        [String[]]
+        $DomainName
+    )
+    Begin {
+        $serviceParams = @{
+            Scope       = 'https://www.googleapis.com/auth/admin.directory.domain'
+            ServiceType = 'Google.Apis.Admin.Directory.directory_v1.DirectoryService'
+        }
+        $service = New-GoogleService @serviceParams
+    }
+    Process {
+        if ($PSBoundParameters.ContainsKey('DomainName')) {
+            foreach ($domain in $DomainName) {
+                try {
+                    Write-Verbose "Getting Domain '$domain'"
+                    $request = $service.Domains.Get($Script:PSGSuite.CustomerId,$domain)
+                    $request.Execute()
+                }
+                catch {
+                    if ($ErrorActionPreference -eq 'Stop') {
+                        $PSCmdlet.ThrowTerminatingError($_)
+                    }
+                    else {
+                        Write-Error $_
+                    }
+                }
+            }
+        }
+        else {
+            try {
+                Write-Verbose "Getting the list of Domains"
+                $request = $service.Domains.List($Script:PSGSuite.CustomerId)
+                $request.Execute().Domains
+            }
+            catch {
+                if ($ErrorActionPreference -eq 'Stop') {
+                    $PSCmdlet.ThrowTerminatingError($_)
+                }
+                else {
+                    Write-Error $_
+                }
+            }
+        }
+    }
+}

--- a/PSGSuite/Public/Domains/Get-GSDomainAlias.ps1
+++ b/PSGSuite/Public/Domains/Get-GSDomainAlias.ps1
@@ -1,0 +1,85 @@
+function Get-GSDomainAlias {
+    <#
+    .SYNOPSIS
+    Retrieves a Domain Alias
+
+    .DESCRIPTION
+    Retrieves a Domain Alias
+
+    .PARAMETER DomainAliasName
+    Name of the domain alias to retrieve.
+
+    If excluded, returns the list of domain aliases.
+
+    .PARAMETER ParentDomainName
+    Name of the parent domain to list aliases for.
+
+    If excluded, lists all aliases for all domains.
+
+    .EXAMPLE
+    Get-GSDDomainAlias
+
+    Returns the list of domain aliases for all domains.
+    #>
+    [OutputType('Google.Apis.Admin.Directory.directory_v1.Data.DomainAlias')]
+    [CmdletBinding(DefaultParameterSetName = "List")]
+    Param(
+        [Parameter(Position = 0,ValueFromPipeline,ValueFromPipelineByPropertyName,ParameterSetName = "Get")]
+        [Alias('DomainAlias')]
+        [String[]]
+        $DomainAliasName,
+        [Parameter(Position = 0,ValueFromPipeline,ValueFromPipelineByPropertyName,ParameterSetName = "List")]
+        [String[]]
+        $ParentDomainName
+    )
+    Begin {
+        $serviceParams = @{
+            Scope       = 'https://www.googleapis.com/auth/admin.directory.domain'
+            ServiceType = 'Google.Apis.Admin.Directory.directory_v1.DirectoryService'
+        }
+        $service = New-GoogleService @serviceParams
+    }
+    Process {
+        if ($PSBoundParameters.ContainsKey('DomainAliasName')) {
+            foreach ($alias in $DomainAliasName) {
+                try {
+                    Write-Verbose "Getting DomainAlias '$alias'"
+                    $request = $service.DomainAliases.Get($Script:PSGSuite.CustomerId,$alias)
+                    $request.Execute()
+                }
+                catch {
+                    if ($ErrorActionPreference -eq 'Stop') {
+                        $PSCmdlet.ThrowTerminatingError($_)
+                    }
+                    else {
+                        Write-Error $_
+                    }
+                }
+            }
+        }
+        else {
+            try {
+                $request = $service.DomainAliases.List($Script:PSGSuite.CustomerId)
+                if ($PSBoundParameters.ContainsKey('ParentDomainName')) {
+                    foreach ($pDom in $ParentDomainName) {
+                        Write-Verbose "Getting the list of all DomainAliases under parent domain '$pDom'"
+                        $request.ParentDomainName = $pDom
+                        $request.Execute().DomainAliasesValue
+                    }
+                }
+                else {
+                    Write-Verbose "Getting the list of all DomainAliases"
+                    $request.Execute().DomainAliasesValue
+                }
+            }
+            catch {
+                if ($ErrorActionPreference -eq 'Stop') {
+                    $PSCmdlet.ThrowTerminatingError($_)
+                }
+                else {
+                    Write-Error $_
+                }
+            }
+        }
+    }
+}

--- a/PSGSuite/Public/Domains/New-GSDomain.ps1
+++ b/PSGSuite/Public/Domains/New-GSDomain.ps1
@@ -1,0 +1,50 @@
+function New-GSDomain {
+    <#
+    .SYNOPSIS
+    Adds a new Domain
+
+    .DESCRIPTION
+    Adds a new Domain
+
+    .PARAMETER DomainName
+    Name of the domain to add.
+
+    .EXAMPLE
+    New-GSDDomain -DomainName 'testing.com'
+
+    Adds a new domain named 'testing.com'
+    #>
+    [OutputType('Google.Apis.Admin.Directory.directory_v1.Data.Domains')]
+    [CmdletBinding()]
+    Param(
+        [Parameter(Position = 0,ValueFromPipeline,ValueFromPipelineByPropertyName)]
+        [Alias('Domain')]
+        [String]
+        $DomainName
+    )
+    Begin {
+        $serviceParams = @{
+            Scope       = 'https://www.googleapis.com/auth/admin.directory.domain'
+            ServiceType = 'Google.Apis.Admin.Directory.directory_v1.DirectoryService'
+        }
+        $service = New-GoogleService @serviceParams
+    }
+    Process {
+        try {
+            Write-Verbose "Adding Domain '$DomainName'"
+            $body = New-Object 'Google.Apis.Admin.Directory.directory_v1.Data.Domains' -Property @{
+                DomainName = $DomainName
+            }
+            $request = $service.Domains.Insert($body,$Script:PSGSuite.CustomerId)
+            $request.Execute()
+        }
+        catch {
+            if ($ErrorActionPreference -eq 'Stop') {
+                $PSCmdlet.ThrowTerminatingError($_)
+            }
+            else {
+                Write-Error $_
+            }
+        }
+    }
+}

--- a/PSGSuite/Public/Domains/New-GSDomainAlias.ps1
+++ b/PSGSuite/Public/Domains/New-GSDomainAlias.ps1
@@ -1,0 +1,57 @@
+function New-GSDomainAlias {
+    <#
+    .SYNOPSIS
+    Adds a new Domain Alias
+
+    .DESCRIPTION
+    Adds a new Domain Alias
+
+    .PARAMETER DomainAliasName
+    Name of the domain alias to add.
+
+    .PARAMETER ParentDomainName
+    Name of the parent domain to add the alias for.
+
+    .EXAMPLE
+    New-GSDDomainAlias -DomainAliasName 'testingalias.com' -ParentDomainName 'testing.com'
+
+    Adds a new domain alias named 'testingalias.com' to parent domain 'testing.com'
+    #>
+    [OutputType('Google.Apis.Admin.Directory.directory_v1.Data.DomainAlias')]
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory,Position = 0,ValueFromPipeline,ValueFromPipelineByPropertyName)]
+        [Alias('DomainAlias')]
+        [String]
+        $DomainAliasName,
+        [Parameter(Mandatory,Position = 1,ValueFromPipeline,ValueFromPipelineByPropertyName)]
+        [String]
+        $ParentDomainName
+    )
+    Begin {
+        $serviceParams = @{
+            Scope       = 'https://www.googleapis.com/auth/admin.directory.domain'
+            ServiceType = 'Google.Apis.Admin.Directory.directory_v1.DirectoryService'
+        }
+        $service = New-GoogleService @serviceParams
+    }
+    Process {
+        try {
+            Write-Verbose "Adding DomainAlias '$DomainAliasName' to domain '$ParentDomainName'"
+            $body = New-Object 'Google.Apis.Admin.Directory.directory_v1.Data.DomainAlias' -Property @{
+                DomainAliasName = $DomainAliasName
+                ParentDomainName = $ParentDomainName
+            }
+            $request = $service.DomainAliases.Insert($body,$Script:PSGSuite.CustomerId)
+            $request.Execute()
+        }
+        catch {
+            if ($ErrorActionPreference -eq 'Stop') {
+                $PSCmdlet.ThrowTerminatingError($_)
+            }
+            else {
+                Write-Error $_
+            }
+        }
+    }
+}

--- a/PSGSuite/Public/Domains/Remove-GSDomainAlias.ps1
+++ b/PSGSuite/Public/Domains/Remove-GSDomainAlias.ps1
@@ -1,25 +1,25 @@
-function Remove-GSDomain {
+function Remove-GSDomainAlias {
     <#
     .SYNOPSIS
-    Removes a Domain
+    Removes a Domain Alias
 
     .DESCRIPTION
-    Removes a Domain
+    Removes a Domain Alias
 
     .PARAMETER DomainName
     Name of the domain to remove.
 
     .EXAMPLE
-    Remove-GSDDomain 'testing.com'
+    Remove-GSDDomainAlias 'testingalias.com'
 
-    Removes the 'testing.com' domain from your account.
+    Removes the 'testingalias.com' domain alias from your account.
     #>
     [CmdletBinding(SupportsShouldProcess = $true,ConfirmImpact = "High")]
     Param(
         [Parameter(Position = 0,ValueFromPipeline,ValueFromPipelineByPropertyName)]
-        [Alias('Domain')]
+        [Alias('DomainAlias')]
         [String[]]
-        $DomainName
+        $DomainAliasName
     )
     Begin {
         $serviceParams = @{
@@ -29,13 +29,13 @@ function Remove-GSDomain {
         $service = New-GoogleService @serviceParams
     }
     Process {
-        foreach ($domain in $DomainName) {
+        foreach ($alias in $DomainAliasName) {
             try {
-                if ($PSCmdlet.ShouldProcess("Removing Domain '$domain'")) {
-                    Write-Verbose "Removing Domain '$domain'"
-                    $request = $service.Domains.Get($Script:PSGSuite.CustomerId,$domain)
+                if ($PSCmdlet.ShouldProcess("Removing Domain Alias '$domain'")) {
+                    Write-Verbose "Removing Domain Alias '$alias'"
+                    $request = $service.DomainAliases.Delete($Script:PSGSuite.CustomerId,$alias)
                     $request.Execute()
-                    Write-Verbose "Domain '$domain' removed successfully"
+                    Write-Verbose "Domain Alias '$alias' removed successfully"
                 }
             }
             catch {

--- a/PSGSuite/Public/Helpers/Add-GSCustomerPostalAddress.ps1
+++ b/PSGSuite/Public/Helpers/Add-GSCustomerPostalAddress.ps1
@@ -1,0 +1,117 @@
+function Add-GSCustomerPostalAddress {
+    <#
+    .SYNOPSIS
+    Builds a PostalAddress object to use when creating or updating a Customer
+
+    .DESCRIPTION
+    Builds a PostalAddress object to use when creating or updating a Customer
+
+    .PARAMETER AddressLine1
+    A customer's physical address. The address can be composed of one to three lines.
+
+    .PARAMETER AddressLine2
+    Address line 2 of the address.
+
+    .PARAMETER AddressLine3
+    Address line 3 of the address.
+
+    .PARAMETER ContactName
+    The customer contact's name.
+
+    .PARAMETER CountryCode
+    The country code. Uses the ISO 3166-1 standard: http://www.iso.org/iso/iso-3166-1_decoding_table
+
+    .PARAMETER Locality
+    Name of the locality. An example of a locality value is the city of San Francisco.
+
+    .PARAMETER OrganizationName
+    The company or company division name.
+
+    .PARAMETER PostalCode
+    The postal code. A postalCode example is a postal zip code such as 10009. This is in accordance with - http://portablecontacts.net/draft-spec.html#address_element.
+
+    .PARAMETER Region
+    Name of the region. An example of a region value is NY for the state of New York.
+
+    .PARAMETER InputObject
+    Used for pipeline input of an existing UserAddress object to strip the extra attributes and prevent errors
+    #>
+    [OutputType('Google.Apis.Admin.Directory.directory_v1.Data.CustomerPostalAddress')]
+    [CmdletBinding(DefaultParameterSetName = "InputObject")]
+    Param
+    (
+        [Parameter(Mandatory = $false, ParameterSetName = "Fields")]
+        [String]
+        $AddressLine1,
+        [Parameter(Mandatory = $false, ParameterSetName = "Fields")]
+        [String]
+        $AddressLine2,
+        [Parameter(Mandatory = $false, ParameterSetName = "Fields")]
+        [String]
+        $AddressLine3,
+        [Parameter(Mandatory = $false, ParameterSetName = "Fields")]
+        [String]
+        $ContactName,
+        [Parameter(Mandatory = $false, ParameterSetName = "Fields")]
+        [String]
+        $CountryCode,
+        [Parameter(Mandatory = $false, ParameterSetName = "Fields")]
+        [Alias('Town', 'City')]
+        [String]
+        $Locality,
+        [Parameter(Mandatory = $false, ParameterSetName = "Fields")]
+        [String]
+        $OrganizationName,
+        [Parameter(Mandatory = $false, ParameterSetName = "Fields")]
+        [String]
+        $PostalCode,
+        [Parameter(Mandatory = $false, ParameterSetName = "Fields")]
+        [Alias('State', 'Province')]
+        [String]
+        $Region,
+        [Parameter(Mandatory = $false, ValueFromPipeline = $true, ParameterSetName = "InputObject")]
+        [Google.Apis.Admin.Directory.directory_v1.Data.CustomerPostalAddress]
+        $InputObject
+    )
+    Begin {
+        $propsToWatch = @(
+            'AddressLine1'
+            'AddressLine2'
+            'AddressLine3'
+            'ContactName'
+            'CountryCode'
+            'Locality'
+            'OrganizationName'
+            'PostalCode'
+            'Region'
+        )
+    }
+    Process {
+        try {
+            switch ($PSCmdlet.ParameterSetName) {
+                Fields {
+                    $obj = New-Object 'Google.Apis.Admin.Directory.directory_v1.Data.CustomerPostalAddress'
+                    foreach ($prop in $PSBoundParameters.Keys | Where-Object {$obj.PSObject.Properties.Name -contains $_}) {
+                        $obj.$prop = $PSBoundParameters[$prop]
+                    }
+                    $obj
+                }
+                InputObject {
+                    $obj = New-Object 'Google.Apis.Admin.Directory.directory_v1.Data.CustomerPostalAddress'
+                    foreach ($prop in $InputObject.PSObject.Properties.Name | Where-Object {$obj.PSObject.Properties.Name -contains $_ -and $propsToWatch -contains $_}) {
+                        $obj.$prop = $InputObject.$prop
+                    }
+                    $obj
+                }
+            }
+        }
+        catch {
+            if ($ErrorActionPreference -eq 'Stop') {
+                $PSCmdlet.ThrowTerminatingError($_)
+            }
+            else {
+                Write-Error $_
+            }
+        }
+    }
+}

--- a/PSGSuite/Public/Org Units/Update-GSOrganizationalUnit.ps1
+++ b/PSGSuite/Public/Org Units/Update-GSOrganizationalUnit.ps1
@@ -71,10 +71,13 @@
         try {
             $body = switch ($PSCmdlet.ParameterSetName) {
                 Path {
-                    Get-GSOrganizationalUnit -OrgUnitPath $OrgUnitPath -Verbose:$false
+                    Get-GSOrganizationalUnit -SearchBase $OrgUnitPath -SearchScope Base -Verbose:$false
                 }
                 Id {
-                    Get-GSOrganizationalUnit -OrgUnitPath $OrgUnitID -Verbose:$false
+                    if ($OrgUnitID -notmatch '^id\:') {
+                        $OrgUnitID = "id:$OrgUnitID"
+                    }
+                    Get-GSOrganizationalUnit -SearchBase $OrgUnitID -SearchScope Base -Verbose:$false
                 }
             }
             if ($ParentOrgUnitPath) {

--- a/README.md
+++ b/README.md
@@ -158,32 +158,24 @@ All other functions are either intact or have an alias included to support backw
 
 [Full CHANGELOG here](https://github.com/scrthq/PSGSuite/blob/master/CHANGELOG.md)
 
-#### 2.30.2
+#### 2.31.0
 
-* [Issue #212](https://github.com/scrthq/PSGSuite/issues/212)
-  * Fixed: `Get-GSUserLicense` no longer short circuiting after first license match when processing pipeline input
-  * Updated: License SKU order to check most common license types first for `Get-GSUserLicense`, which should result in faster overall processing when working with a large amount of users.
-
-#### 2.30.1
-
+* [Issue #218](https://github.com/scrthq/PSGSuite/issues/218)
+  * Fixed: `Update-GSOrganizationalUnit` was failing with `null` reference errors.
+* [Issue #213](https://github.com/scrthq/PSGSuite/issues/213)
+  * Added: Support for `RELEASE_RESOURCES` TransferParam for Calendar application data transfers to function `Start-GSDataTransfer`
+* [Issue #215](https://github.com/scrthq/PSGSuite/issues/215)
+  * Added:
+    * `Get-GSDomain`
+    * `Remove-GSDomain`
+    * `New-GSDomain`
+    * `Get-GSDomainAlias`
+    * `New-GSDomainAlias`
+    * `Remove-GSDomainAlias`
+  * _These will need the additional scope of `https://www.googleapis.com/auth/admin.directory.domain` added in order to use!_
 * Miscellaneous
-  * Fixed: `Remove-GSDrivePermission` duplicate parameter alias prevented usage after module update.
-
-#### 2.30.0
-
-* [Issue #193](https://github.com/scrthq/PSGSuite/issues/193)
-  * Added: Drive Revision functions:
-    * `Get-GSDriveRevision`
-    * `Remove-GSDriveRevision`
-    * `Update-GSDriveRevision`
-* [Issue #210](https://github.com/scrthq/PSGSuite/issues/210)
-  * Fixed: `Update-GSUser` was not accepting User ID's as the User parameter
-* [Issue #209](https://github.com/scrthq/PSGSuite/issues/209)
-  * Added: Support for inline image downloading with `Get-GSGmailMessage` where the image is not included on the Attachments property of the parsed message object.
-  * Fixed: `Get-GSGmailMessage` will now automatically set the `Format` to `Raw` if either `ParseMessage` or `SaveAttachmentsTo` is passed, as `ParseMessage` is a requirement in order to be able to access the message attachments as needed.
-* [Issue #204](https://github.com/scrthq/PSGSuite/issues/204)
-  * Added: `Recurse` parameter to `Get-GSDriveFileList` to allow recursively listing all files and subfolders underneath the result set. Confirmed setting the `Limit` parameter also works as expected with `Recurse` included, stopping is the original limit is reached.
-  * Added: `Get-GSDriveFolderSize` function to return the calculated total size of the files in the specified folder(s).
-* Miscellaneous
-  * Added: `Rfc822MsgId` parameter to `Get-GSGmailMessageList` to easily build a query looking for a specific RFS 822 Message ID.
-  * Added: Pipeline support for `*-GSDrivePermission` functions to enable piping Drive Files into them to manage permissions without looping manually.
+  * Added:
+    * `Get-GSCustomer`
+    * `Update-GSCustomer`
+    * `Add-GSCustomerPostalAddress`
+  * _These will need the additional scope of `https://www.googleapis.com/auth/admin.directory.customer` added in order to use!_


### PR DESCRIPTION
## 2.31.0

* [Issue #218](https://github.com/scrthq/PSGSuite/issues/218)
  * Fixed: `Update-GSOrganizationalUnit` was failing with `null` reference errors.
* [Issue #213](https://github.com/scrthq/PSGSuite/issues/213)
  * Added: Support for `RELEASE_RESOURCES` TransferParam for Calendar application data transfers to function `Start-GSDataTransfer`
* [Issue #215](https://github.com/scrthq/PSGSuite/issues/215)
  * Added:
    * `Get-GSDomain`
    * `Remove-GSDomain`
    * `New-GSDomain`
    * `Get-GSDomainAlias`
    * `New-GSDomainAlias`
    * `Remove-GSDomainAlias`
  * _These will need the additional scope of `https://www.googleapis.com/auth/admin.directory.domain` added in order to use!_
* Miscellaneous
  * Added:
    * `Get-GSCustomer`
    * `Update-GSCustomer`
    * `Add-GSCustomerPostalAddress`
  * _These will need the additional scope of `https://www.googleapis.com/auth/admin.directory.customer` added in order to use!_