### PR TITLE
!deploy v2.31.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 * [PSGSuite - ChangeLog](#psgsuite---changelog)
+  * [2.31.1](#2311)
   * [2.31.0](#2310)
   * [2.30.2](#2302)
   * [2.30.1](#2301)
@@ -94,6 +95,11 @@
 ***
 
 # PSGSuite - ChangeLog
+
+## 2.31.1
+
+* [Issue #222](https://github.com/scrthq/PSGSuite/issues/222)
+  * Fixed: `Remove-GSUserASP` and `Remove-GSUserToken` not removing all when no Id is passed due to no service being created.
 
 ## 2.31.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,13 @@
 
 * [Issue #222](https://github.com/scrthq/PSGSuite/issues/222)
   * Fixed: `Remove-GSUserASP` and `Remove-GSUserToken` not removing all when no Id is passed due to no service being created.
+* [Issue #225](https://github.com/scrthq/PSGSuite/issues/225)
+  * Added: `RecoveryEmail` and `RecoveryPhone` parameters to `Update-GSUser`
+* [Issue #189](https://github.com/scrthq/PSGSuite/issues/189)
+  * Removed `$env:UserName` from the application name when creating the client in `New-GoogleService` to prevent errors with the underlying .NET SDK.
+* Miscellaneous
+  * Fixed: Corrected logic on the `FullName` parameter on `Update-GSUser` to parse the name parts.
+  * Updated Google .NET SDKs to latest versions.
 
 ## 2.31.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 * [PSGSuite - ChangeLog](#psgsuite---changelog)
-  * [2.31.1](#2311)
+  * [2.31.1 - 2019-08-30](#2311---2019-08-30)
   * [2.31.0](#2310)
   * [2.30.2](#2302)
   * [2.30.1](#2301)
@@ -96,7 +96,7 @@
 
 # PSGSuite - ChangeLog
 
-## 2.31.1
+## 2.31.1 - 2019-08-30
 
 * [Issue #222](https://github.com/scrthq/PSGSuite/issues/222)
   * Fixed: `Remove-GSUserASP` and `Remove-GSUserToken` not removing all when no Id is passed due to no service being created.

--- a/PSGSuite/PSGSuite.psd1
+++ b/PSGSuite/PSGSuite.psd1
@@ -12,7 +12,7 @@
     RootModule            = 'PSGSuite.psm1'
 
     # Version number of this module.
-    ModuleVersion         = '2.31.0'
+    ModuleVersion         = '2.31.1'
 
     # ID used to uniquely identify this module
     GUID                  = '9d751152-e83e-40bb-a6db-4c329092aaec'

--- a/PSGSuite/Public/Authentication/New-GoogleService.ps1
+++ b/PSGSuite/Public/Authentication/New-GoogleService.ps1
@@ -94,7 +94,7 @@ function New-GoogleService {
             }
             $svc = New-Object "$ServiceType" (New-Object 'Google.Apis.Services.BaseClientService+Initializer' -Property @{
                     HttpClientInitializer = $credential
-                    ApplicationName       = "PSGSuite - $env:USERNAME"
+                    ApplicationName       = "PSGSuite"
                 }
             )
             $script:_PSGSuiteSessions[$sessionKey] = ([PSCustomObject]@{

--- a/PSGSuite/Public/Security/Remove-GSUserASP.ps1
+++ b/PSGSuite/Public/Security/Remove-GSUserASP.ps1
@@ -2,16 +2,16 @@
     <#
     .SYNOPSIS
     Removes an Application Specific Password for a user
-    
+
     .DESCRIPTION
     Removes an Application Specific Password for a user
-    
+
     .PARAMETER User
     The user to remove ASPs ValueFromPipeline
-    
+
     .PARAMETER CodeId
     The ASP Code Id to remove. If excluded, all ASPs for the user will be removed
-    
+
     .EXAMPLE
     Remove-GSUserASP -User joe
 
@@ -30,13 +30,11 @@
         $CodeId
     )
     Begin {
-        if ($PSBoundParameters.Keys -contains 'CodeId') {
-            $serviceParams = @{
-                Scope       = 'https://www.googleapis.com/auth/admin.directory.user.security'
-                ServiceType = 'Google.Apis.Admin.Directory.directory_v1.DirectoryService'
-            }
-            $service = New-GoogleService @serviceParams
+        $serviceParams = @{
+            Scope       = 'https://www.googleapis.com/auth/admin.directory.user.security'
+            ServiceType = 'Google.Apis.Admin.Directory.directory_v1.DirectoryService'
         }
+        $service = New-GoogleService @serviceParams
     }
     Process {
         try {

--- a/PSGSuite/Public/Security/Remove-GSUserToken.ps1
+++ b/PSGSuite/Public/Security/Remove-GSUserToken.ps1
@@ -2,19 +2,19 @@
     <#
     .SYNOPSIS
     Removes a security token from a user
-    
+
     .DESCRIPTION
     Removes a security token from a user
-    
+
     .PARAMETER User
     The user to remove the security token from
-    
+
     .PARAMETER ClientID
     The client Id of the security token. If excluded, all security tokens for the user are removed
-    
+
     .EXAMPLE
     An example
-    
+
     .NOTES
     General notes
     #>
@@ -31,13 +31,11 @@
         $ClientID
     )
     Begin {
-        if ($PSBoundParameters.Keys -contains 'ClientID') {
-            $serviceParams = @{
-                Scope       = 'https://www.googleapis.com/auth/admin.directory.user.security'
-                ServiceType = 'Google.Apis.Admin.Directory.directory_v1.DirectoryService'
-            }
-            $service = New-GoogleService @serviceParams
+        $serviceParams = @{
+            Scope       = 'https://www.googleapis.com/auth/admin.directory.user.security'
+            ServiceType = 'Google.Apis.Admin.Directory.directory_v1.DirectoryService'
         }
+        $service = New-GoogleService @serviceParams
     }
     Process {
         try {

--- a/README.md
+++ b/README.md
@@ -158,6 +158,18 @@ All other functions are either intact or have an alias included to support backw
 
 [Full CHANGELOG here](https://github.com/scrthq/PSGSuite/blob/master/CHANGELOG.md)
 
+#### 2.31.1 - 2019-08-30
+
+* [Issue #222](https://github.com/scrthq/PSGSuite/issues/222)
+  * Fixed: `Remove-GSUserASP` and `Remove-GSUserToken` not removing all when no Id is passed due to no service being created.
+* [Issue #225](https://github.com/scrthq/PSGSuite/issues/225)
+  * Added: `RecoveryEmail` and `RecoveryPhone` parameters to `Update-GSUser`
+* [Issue #189](https://github.com/scrthq/PSGSuite/issues/189)
+  * Removed `$env:UserName` from the application name when creating the client in `New-GoogleService` to prevent errors with the underlying .NET SDK.
+* Miscellaneous
+  * Fixed: Corrected logic on the `FullName` parameter on `Update-GSUser` to parse the name parts.
+  * Updated Google .NET SDKs to latest versions.
+
 #### 2.31.0
 
 * [Issue #218](https://github.com/scrthq/PSGSuite/issues/218)

--- a/build.ps1
+++ b/build.ps1
@@ -1,56 +1,20 @@
-﻿
-[cmdletbinding(DefaultParameterSetName = 'task')]
+﻿[cmdletbinding(DefaultParameterSetName = 'task')]
 param(
     [parameter(ParameterSetName = 'task', Position = 0)]
     [ValidateSet('Init','Clean','Compile','Import','Test','TestOnly','Deploy','Skip')]
     [string[]]
     $Task = @('Init','Clean','Compile','Import'),
-
-    [parameter(ParameterSetName = 'help')]
-    [switch]$Help,
+    [parameter(ParameterSetName = 'task')]
+    [Alias('nr','nor')]
+    [switch]$NoRestore,
 
     [switch]$UpdateModules,
-    [switch]$Force
+    [switch]$Force,
+
+    [parameter(ParameterSetName = 'help')]
+    [switch]$Help
 )
-
-$env:BuildProjectName = 'PSGSuite'
 $env:_BuildStart = Get-Date -Format 'o'
-$env:BuildScriptPath = $PSScriptRoot
-
-. ([System.IO.Path]::Combine($PSScriptRoot,"ci","AzurePipelinesHelpers.ps1"))
-
-Add-EnvironmentSummary "Build started"
-
-Set-BuildVariables
-
-Add-Heading "Setting package feeds"
-
-$modHash = @{
-    PackageManagement = '1.3.1'
-    PowerShellGet     = '2.1.2'
-}
-foreach ($module in $modHash.Keys | Sort-Object) {
-    Write-BuildLog "Updating $module module if needed"
-    if ($null -eq (Get-Module $module -ListAvailable | Where-Object {[System.Version]$_.Version -ge [System.Version]($modHash[$module])})) {
-        Write-BuildLog "$module is below the minimum required version! Updating"
-        Install-Module $module -MinimumVersion $modHash[$module] -Force -AllowClobber -SkipPublisherCheck -Scope CurrentUser -Verbose:$false
-    }
-}
-
-Invoke-CommandWithLog {Get-PackageProvider -Name Nuget -ForceBootstrap -Verbose:$false}
-Invoke-CommandWithLog {Set-PSRepository -Name PSGallery -InstallationPolicy Trusted -Verbose:$false}
-Invoke-CommandWithLog {$PSDefaultParameterValues = @{
-    '*-Module:Verbose' = $false
-    'Import-Module:ErrorAction' = 'Stop'
-    'Import-Module:Force' = $true
-    'Import-Module:Verbose' = $false
-    'Install-Module:AllowClobber' = $true
-    'Install-Module:ErrorAction' = 'Stop'
-    'Install-Module:Force' = $true
-    'Install-Module:Scope' = 'CurrentUser'
-    'Install-Module:Verbose' = $false
-}}
-
 $update = @{}
 $verbose = @{}
 if ($PSBoundParameters.ContainsKey('UpdateModules')) {
@@ -60,16 +24,54 @@ if ($PSBoundParameters.ContainsKey('Verbose')) {
     $verbose['Verbose'] = $PSBoundParameters['Verbose']
 }
 
+. ([System.IO.Path]::Combine($PSScriptRoot,"ci","AzurePipelinesHelpers.ps1"))
+
 if ($Help) {
     Add-Heading "Getting help"
-    Write-BuildLog -c '"psake" | Resolve-Module @update -Verbose'
-    'psake' | Resolve-Module @update -Verbose
+    Write-BuildLog -c '"psake" | Resolve-Module @update @Verbose'
+    'psake' | Resolve-Module @update @verbose
     Write-BuildLog "psake script tasks:"
     Get-PSakeScriptTasks -buildFile "$PSScriptRoot\psake.ps1" |
         Sort-Object -Property Name |
         Format-Table -Property Name, Description, Alias, DependsOn
 }
 else {
+    $env:BuildProjectName = 'PSGSuite'
+    $env:BuildScriptPath = $PSScriptRoot
+    $env:NoNugetRestore = $NoRestore
+
+    Add-EnvironmentSummary "Build started"
+
+    Set-BuildVariables
+
+    Add-Heading "Setting package feeds"
+
+    $modHash = @{
+        PackageManagement = '1.3.1'
+        PowerShellGet     = '2.1.2'
+    }
+    foreach ($module in $modHash.Keys | Sort-Object) {
+        Write-BuildLog "Updating $module module if needed"
+        if ($null -eq (Get-Module $module -ListAvailable | Where-Object {[System.Version]$_.Version -ge [System.Version]($modHash[$module])})) {
+            Write-BuildLog "$module is below the minimum required version! Updating"
+            Install-Module $module -MinimumVersion $modHash[$module] -Force -AllowClobber -SkipPublisherCheck -Scope CurrentUser -Verbose:$false
+        }
+    }
+
+    Invoke-CommandWithLog {Get-PackageProvider -Name Nuget -ForceBootstrap -Verbose:$false}
+    Invoke-CommandWithLog {Set-PSRepository -Name PSGallery -InstallationPolicy Trusted -Verbose:$false}
+    Invoke-CommandWithLog {$PSDefaultParameterValues = @{
+        '*-Module:Verbose' = $false
+        'Import-Module:ErrorAction' = 'Stop'
+        'Import-Module:Force' = $true
+        'Import-Module:Verbose' = $false
+        'Install-Module:AllowClobber' = $true
+        'Install-Module:ErrorAction' = 'Stop'
+        'Install-Module:Force' = $true
+        'Install-Module:Scope' = 'CurrentUser'
+        'Install-Module:Verbose' = $false
+    }}
+
     Add-Heading "Finalizing build prerequisites"
     if (
         $Task -eq 'Deploy' -and -not $Force -and (

--- a/build.ps1
+++ b/build.ps1
@@ -1,17 +1,15 @@
-﻿[cmdletbinding(DefaultParameterSetName = 'task')]
+﻿[cmdletbinding()]
 param(
-    [parameter(ParameterSetName = 'task', Position = 0)]
+    [parameter( Position = 0)]
     [ValidateSet('Init','Clean','Compile','Import','Test','TestOnly','Deploy','Skip')]
     [string[]]
     $Task = @('Init','Clean','Compile','Import'),
-    [parameter(ParameterSetName = 'task')]
+    [parameter()]
     [Alias('nr','nor')]
     [switch]$NoRestore,
 
     [switch]$UpdateModules,
     [switch]$Force,
-
-    [parameter(ParameterSetName = 'help')]
     [switch]$Help
 )
 $env:_BuildStart = Get-Date -Format 'o'

--- a/ci/AzurePipelinesHelpers.ps1
+++ b/ci/AzurePipelinesHelpers.ps1
@@ -195,6 +195,9 @@ function Add-Heading {
         [Switch]
         $Passthru
     )
+    if (-not $env:_BuildStart) {
+        $env:_BuildStart = Get-Date -Format 'o'
+    }
     $date = "[$((Get-Date).ToString("HH:mm:ss")) +$(((Get-Date) - (Get-Date $env:_BuildStart)).ToString())]"
     $msgList = @(
         ''
@@ -281,6 +284,9 @@ function Write-BuildLog {
         $Clean
     )
     Begin {
+        if (-not $env:_BuildStart) {
+            $env:_BuildStart = Get-Date -Format 'o'
+        }
         if ($PSBoundParameters.ContainsKey('Debug') -and $PSBoundParameters['Debug'] -eq $true) {
             $fg = 'Yellow'
             $lvl = '##[debug]   '
@@ -382,7 +388,6 @@ function Set-EnvironmentVariable {
         $Value
     )
     $fullVal = $Value -join " "
-    Write-BuildLog "Setting env variable '$Name' to '$fullVal'"
     Set-Item -Path Env:\$Name -Value $fullVal -Force
     if ($IsCI) {
         "##vso[task.setvariable variable=$Name]$fullVal" | Write-Host
@@ -419,7 +424,6 @@ function Set-BuildVariables {
             BHCommitMessage = $((git log --format=%B -n 1).Trim())
         }
     }
-    Add-Heading 'Setting environment variables if needed'
     foreach ($var in $gitVars.Keys) {
         if (-not (Test-Path Env:\$var)) {
             Set-EnvironmentVariable $var $gitVars[$var]


### PR DESCRIPTION
## 2.31.1 - 2019-08-30

* [Issue #222](https://github.com/scrthq/PSGSuite/issues/222)
  * Fixed: `Remove-GSUserASP` and `Remove-GSUserToken` not removing all when no Id is passed due to no service being created.
* [Issue #225](https://github.com/scrthq/PSGSuite/issues/225)
  * Added: `RecoveryEmail` and `RecoveryPhone` parameters to `Update-GSUser`
* [Issue #189](https://github.com/scrthq/PSGSuite/issues/189)
  * Removed `$env:UserName` from the application name when creating the client in `New-GoogleService` to prevent errors with the underlying .NET SDK.
* Miscellaneous
  * Fixed: Corrected logic on the `FullName` parameter on `Update-GSUser` to parse the name parts.
  * Updated Google .NET SDKs to latest versions.