### PR TITLE
!deploy v2.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 * [PSGSuite - ChangeLog](#psgsuite---changelog)
-    * [2.40.0 - 2019-10-31](#2400---2019-10-31)
+    * [2.34.0 - 2019-11-02](#2340---2019-11-02)
     * [2.33.2 - 2019-10-06](#2332---2019-10-06)
     * [2.33.1 - 2019-10-06](#2331---2019-10-06)
     * [2.33.0 - 2019-09-26](#2330---2019-09-26)
@@ -104,9 +104,9 @@
 
 # PSGSuite - ChangeLog
 
-## 2.40.0 - 2019-10-31
+## 2.34.0 - 2019-11-02
 
-* [Issue #245](https://github.com/scrthq/PSGSuite/issues/245)
+* [Issue #245](https://github.com/scrthq/PSGSuite/issues/245) + [PR #246](https://github.com/scrthq/PSGSuite/pull/246) - _Thank you, [@devblackops](https://github.com/devblackops)!_
     * Added: Optional `-CreateMeetEvent` switch parameter to `New-GSCalendarEvent` to create a Google Meet conference and attach it to the calendar event.
 
 ## 2.33.2 - 2019-10-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 * [PSGSuite - ChangeLog](#psgsuite---changelog)
+    * [2.40.0 - 2019-10-31](#2400---2019-10-31)
     * [2.33.2 - 2019-10-06](#2332---2019-10-06)
     * [2.33.1 - 2019-10-06](#2331---2019-10-06)
     * [2.33.0 - 2019-09-26](#2330---2019-09-26)
@@ -102,6 +103,11 @@
 ***
 
 # PSGSuite - ChangeLog
+
+## 2.40.0 - 2019-10-31
+
+* [Issue #245](https://github.com/scrthq/PSGSuite/issues/245)
+    * Added: Optional `-CreateMeetEvent` switch parameter to `New-GSCalendarEvent` to create a Google Meet conference and attach it to the calendar event.
 
 ## 2.33.2 - 2019-10-06
 

--- a/PSGSuite/PSGSuite.psd1
+++ b/PSGSuite/PSGSuite.psd1
@@ -12,7 +12,7 @@
     RootModule            = 'PSGSuite.psm1'
 
     # Version number of this module.
-    ModuleVersion         = '2.33.2'
+    ModuleVersion         = '2.34.0'
 
     # ID used to uniquely identify this module
     GUID                  = '9d751152-e83e-40bb-a6db-4c329092aaec'

--- a/PSGSuite/PSGSuite.psd1
+++ b/PSGSuite/PSGSuite.psd1
@@ -48,7 +48,7 @@
     ProcessorArchitecture = 'None'
 
     # Modules that must be imported into the global environment prior to importing this module
-    RequiredModules       = @(@{ModuleName = "Configuration"; ModuleVersion = "1.2.0"})
+    RequiredModules       = @(@{ModuleName = "Configuration"; ModuleVersion = "1.3.1" })
 
     # Assemblies that must be loaded prior to importing this module
     RequiredAssemblies    = @()

--- a/PSGSuite/Public/Calendar/New-GSCalendarEvent.ps1
+++ b/PSGSuite/Public/Calendar/New-GSCalendarEvent.ps1
@@ -321,18 +321,17 @@ function New-GSCalendarEvent {
                         DateTime = $LocalEndDateTime
                     }
                 }
+                $verbMsg = $null
+                if ($CreateMeetEvent) {
+                    $createRequest = New-Object 'Google.Apis.Calendar.v3.Data.CreateConferenceRequest'
+                    $createRequest.RequestId = (New-Guid).ToString('n')
+                    $confData = New-Object 'Google.Apis.Calendar.v3.Data.ConferenceData'
+                    $confData.CreateRequest = $createRequest
+                    $body.ConferenceData = $confData
+                    $verbMsg = ' with Meet conferencing'
+                }
                 foreach ($calId in $CalendarID) {
-                    if ($CreateMeetEvent) {
-                        $createRequest = New-Object 'Google.Apis.Calendar.v3.Data.CreateConferenceRequest'
-                        $createRequest.RequestId = (New-Guid).ToString('n')
-                        $confData = New-Object 'Google.Apis.Calendar.v3.Data.ConferenceData'
-                        $confData.CreateRequest = $createRequest
-                        $body.ConferenceData = $confData
-                        Write-Verbose "Creating Calendar Event '$($Summary)' with Meet conferencing on calendar '$calId' for user '$U'"
-                    }
-                    else {
-                        Write-Verbose "Creating Calendar Event '$($Summary)' on calendar '$calId' for user '$U'"
-                    }
+                    Write-Verbose "Creating Calendar Event '$($Summary)'$($verbMsg) on calendar '$calId' for user '$U'"
                     $request = $service.Events.Insert($body,$calId)
                     if ($CreateMeetEvent) {
                         $request.ConferenceDataVersion = 1

--- a/PSGSuite/Public/Calendar/New-GSCalendarEvent.ps1
+++ b/PSGSuite/Public/Calendar/New-GSCalendarEvent.ps1
@@ -114,77 +114,84 @@ function New-GSCalendarEvent {
     [cmdletbinding(DefaultParameterSetName = "AttendeeEmails")]
     Param
     (
-        [parameter(Mandatory = $true,Position = 0)]
+        [parameter(Mandatory,Position = 0)]
         [String]
         $Summary,
-        [parameter(Mandatory = $false)]
+        [parameter()]
         [String]
         $Description,
-        [parameter(Mandatory = $false)]
-        [ValidateScript({if ($_ -match '^[0-9a-v]+$'){$true}else{throw "The characters allowed in the ID are only those used in base32hex encoding, i.e. lowercase letters a-v and digits 0-9"}})]
+        [parameter()]
+        [ValidateScript( { if ($_ -match '^[0-9a-v]+$') {
+                    $true
+                }
+                else {
+                    throw "The characters allowed in the ID are only those used in base32hex encoding, i.e. lowercase letters a-v and digits 0-9"
+                } })]
         [ValidateLength(5,1024)]
         [String]
         $Id,
-        [parameter(Mandatory = $false,ValueFromPipelineByPropertyName = $true)]
+        [parameter(ValueFromPipelineByPropertyName)]
         [Alias("PrimaryEmail","UserKey","Mail")]
         [ValidateNotNullOrEmpty()]
         [String[]]
         $User = $Script:PSGSuite.AdminEmail,
-        [parameter(Mandatory = $false,ValueFromPipelineByPropertyName = $true)]
+        [parameter(ValueFromPipelineByPropertyName)]
         [String[]]
         $CalendarID = "primary",
-        [parameter(Mandatory = $false,ParameterSetName = "AttendeeEmails")]
+        [parameter(ParameterSetName = "AttendeeEmails")]
         [String[]]
         $AttendeeEmails,
-        [parameter(Mandatory = $false,ParameterSetName = "AttendeeObjects")]
+        [parameter(ParameterSetName = "AttendeeObjects")]
         [Google.Apis.Calendar.v3.Data.EventAttendee[]]
         $Attendees,
-        [parameter(Mandatory = $false)]
+        [parameter()]
         [String]
         $Location,
-        [parameter(Mandatory = $false)]
+        [parameter()]
         [ValidateSet('default','public','private','confidential')]
         [String]
         $Visibility,
-        [parameter(Mandatory = $false)]
+        [parameter()]
         [ValidateSet("Periwinkle","Seafoam","Lavender","Coral","Goldenrod","Beige","Cyan","Grey","Blue","Green","Red")]
         [String]
         $EventColor,
         [parameter()]
         [Google.Apis.Calendar.v3.Data.EventReminder[]]
         $Reminders,
-        [parameter(Mandatory = $false)]
+        [parameter()]
         [Alias('DisableReminder')]
         [Switch]
         $DisableDefaultReminder,
-        [parameter(Mandatory = $false)]
+        [parameter()]
         [DateTime]
         $LocalStartDateTime = (Get-Date),
-        [parameter(Mandatory = $false)]
+        [parameter()]
         [DateTime]
         $LocalEndDateTime = (Get-Date).AddMinutes(30),
-        [parameter(Mandatory = $false)]
+        [parameter()]
         [String]
         $StartDate,
-        [parameter(Mandatory = $false)]
+        [parameter()]
         [String]
         $EndDate,
-        [parameter(Mandatory = $false)]
+        [parameter()]
         [String]
         $UTCStartDateTime,
-        [parameter(Mandatory = $false)]
+        [parameter()]
         [String]
         $UTCEndDateTime,
-        [parameter(Mandatory = $false)]
+        [parameter()]
         [Hashtable]
         $PrivateExtendedProperties,
-        [parameter(Mandatory = $false)]
+        [parameter()]
         [Hashtable]
         $SharedExtendedProperties,
-        [parameter(Mandatory = $false)]
+        [parameter()]
         [Google.Apis.Calendar.v3.Data.Event+ExtendedPropertiesData]
         $ExtendedProperties,
-        [switch]$CreateMeetEvent
+        [parameter()]
+        [switch]
+        $CreateMeetEvent
     )
     Begin {
         $colorHash = @{
@@ -235,7 +242,7 @@ function New-GSCalendarEvent {
                             if (-not $ExtendedProperties) {
                                 $ExtendedProperties = New-Object 'Google.Apis.Calendar.v3.Data.Event+ExtendedPropertiesData' -Property @{
                                     Private__ = (New-Object 'System.Collections.Generic.Dictionary[string,string]')
-                                    Shared = (New-Object 'System.Collections.Generic.Dictionary[string,string]')
+                                    Shared    = (New-Object 'System.Collections.Generic.Dictionary[string,string]')
                                 }
                             }
                             elseif (-not $ExtendedProperties.Private__) {
@@ -249,7 +256,7 @@ function New-GSCalendarEvent {
                             if (-not $ExtendedProperties) {
                                 $ExtendedProperties = New-Object 'Google.Apis.Calendar.v3.Data.Event+ExtendedPropertiesData' -Property @{
                                     Private__ = (New-Object 'System.Collections.Generic.Dictionary[string,string]')
-                                    Shared = (New-Object 'System.Collections.Generic.Dictionary[string,string]')
+                                    Shared    = (New-Object 'System.Collections.Generic.Dictionary[string,string]')
                                 }
                             }
                             elseif (-not $ExtendedProperties.Shared) {
@@ -317,21 +324,19 @@ function New-GSCalendarEvent {
                 foreach ($calId in $CalendarID) {
                     if ($CreateMeetEvent) {
                         $createRequest = New-Object 'Google.Apis.Calendar.v3.Data.CreateConferenceRequest'
-                        $createRequest.RequestId = [guid]::NewGuid().ToString().Replace('-','')
+                        $createRequest.RequestId = (New-Guid).ToString('n')
                         $confData = New-Object 'Google.Apis.Calendar.v3.Data.ConferenceData'
                         $confData.CreateRequest = $createRequest
                         $body.ConferenceData = $confData
                         Write-Verbose "Creating Calendar Event '$($Summary)' with Meet conferencing on calendar '$calId' for user '$U'"
-                    } else {
+                    }
+                    else {
                         Write-Verbose "Creating Calendar Event '$($Summary)' on calendar '$calId' for user '$U'"
                     }
-
                     $request = $service.Events.Insert($body,$calId)
-
                     if ($CreateMeetEvent) {
                         $request.ConferenceDataVersion = 1
                     }
-
                     $request.Execute() | Add-Member -MemberType NoteProperty -Name 'User' -Value $U -PassThru | Add-Member -MemberType NoteProperty -Name 'CalendarId' -Value $calId -PassThru
                 }
             }

--- a/README.md
+++ b/README.md
@@ -158,35 +158,7 @@ All other functions are either intact or have an alias included to support backw
 
 [Full CHANGELOG here](https://github.com/scrthq/PSGSuite/blob/master/CHANGELOG.md)
 
-#### 2.40.0 - 2019-10-31
+#### 2.34.0 - 2019-11-02
 
-* [Issue #245](https://github.com/scrthq/PSGSuite/issues/245)
+* [Issue #245](https://github.com/scrthq/PSGSuite/issues/245) + [PR #246](https://github.com/scrthq/PSGSuite/pull/246) - _Thank you, [@devblackops](https://github.com/devblackops)!_
     * Added: Optional `-CreateMeetEvent` switch parameter to `New-GSCalendarEvent` to create a Google Meet conference and attach it to the calendar event.
-
-#### 2.33.2 - 2019-10-06
-
-* [Issue #242](https://github.com/scrthq/PSGSuite/issues/242)
-    * Fixed: Error handling around `[System.Console]::CursorVisible` on `Start-GSDriveFileUpload`, `Wait-GSDriveFileUpload` and `Write-InlineProgress`
-    * Cleaned up verbose handling on `Stop-GSDriveFileUpload` due to file uploads showing as Failed even though they were successful.
-* Miscellaneous
-    * Updated build.ps1 script for better verbose output
-
-#### 2.33.1 - 2019-10-06
-
-* [Issue #235](https://github.com/scrthq/PSGSuite/issues/235)
-    * Removed: `Name` parameter from `Start-GSDriveFileUpload` as it was unused in the function and doesnt make sense when uploading an array of files.
-* [Issue #238](https://github.com/scrthq/PSGSuite/issues/238)
-    * Added: `Get-GSDataTransfer` to Get/List current Data Transfers
-* [Issue #239](https://github.com/scrthq/PSGSuite/issues/239)
-    * Removed: `Update-GSResource` `Id` parameter as it was non-applicable (duplicate of `ResourceId` and not writable per API docs)
-    * Cleaned up function help and examples to match changes
-* [Issue #240](https://github.com/scrthq/PSGSuite/issues/240)
-    * Fixed: `Get-GSCalendar` now properly resolves single calendar metadata retrieval and passes List requests to `Get-GSCalendarSubscription` since the `Calendars` service does not support List requests.
-* Miscellaneous
-    * Updated Google .NET SDKs to latest versions
-    * Cleaned up build.ps1 script
-
-#### 2.33.0 - 2019-09-26
-
-* [Issue #236](https://github.com/scrthq/PSGSuite/issues/236)
-    * Fixed: Custom converter for Configuration metadata defaults to `ConvertTo-SecureString` as the preferred function instead of the custom `Secure`. `Secure` is still supported for backwards compatibility.

--- a/README.md
+++ b/README.md
@@ -158,6 +158,11 @@ All other functions are either intact or have an alias included to support backw
 
 [Full CHANGELOG here](https://github.com/scrthq/PSGSuite/blob/master/CHANGELOG.md)
 
+#### 2.40.0 - 2019-10-31
+
+* [Issue #245](https://github.com/scrthq/PSGSuite/issues/245)
+    * Added: Optional `-CreateMeetEvent` switch parameter to `New-GSCalendarEvent` to create a Google Meet conference and attach it to the calendar event.
+
 #### 2.33.2 - 2019-10-06
 
 * [Issue #242](https://github.com/scrthq/PSGSuite/issues/242)


### PR DESCRIPTION
Fixes #245.

This PR adds the switch parameter `-CreateMeetEvent` to `New-GSCalendarEvent` to create Google Meet conferences and attach them to the calendar event.