### PR TITLE
Improved P12 handling

### DIFF
--- a/PSGSuite/Public/Configuration/Get-PSGSuiteConfig.ps1
+++ b/PSGSuite/Public/Configuration/Get-PSGSuiteConfig.ps1
@@ -69,7 +69,7 @@ function Get-PSGSuiteConfig {
             @{l = 'P12KeyPath';e = {Decrypt $_.P12KeyPath}},
             'P12Key',
             @{l = 'P12KeyPassword';e = {Decrypt $_.P12KeyPassword}},
-            'P12KeyObject',
+            @{l = 'P12KeyObject';e = {Decrypt $_.P12KeyObject}},
             @{l = 'ClientSecretsPath';e = {Decrypt $_.ClientSecretsPath}},
             @{l = 'ClientSecrets';e = {Decrypt $_.ClientSecrets}},
             @{l = 'AppEmail';e = {Decrypt $_.AppEmail}},

--- a/PSGSuite/Public/Configuration/Get-PSGSuiteConfig.ps1
+++ b/PSGSuite/Public/Configuration/Get-PSGSuiteConfig.ps1
@@ -70,14 +70,30 @@ function Get-PSGSuiteConfig {
             'P12Key',
             @{l = 'P12KeyPassword';e = {Decrypt $_.P12KeyPassword}},
             @{l = 'P12KeyObject';e = {Decrypt $_.P12KeyObject}},
+            @{l = 'JSONServiceAccountKeyPath';e = {Decrypt $_.JSONServiceAccountKeyPath}},
+            @{l = 'JSONServiceAccountKey';e = {Decrypt $_.JSONServiceAccountKey}},
             @{l = 'ClientSecretsPath';e = {Decrypt $_.ClientSecretsPath}},
             @{l = 'ClientSecrets';e = {Decrypt $_.ClientSecrets}},
-            @{l = 'AppEmail';e = {Decrypt $_.AppEmail}},
+            @{l = 'AppEmail';e = {
+                if ($_.JSONServiceAccountKey) {
+                    ($_.JSONServiceAccountKey | ConvertFrom-Json).client_email
+                }
+                else {
+                    Decrypt $_.AppEmail
+                }
+            }},
             @{l = 'AdminEmail';e = {Decrypt $_.AdminEmail}},
             @{l = 'CustomerID';e = {Decrypt $_.CustomerID}},
             @{l = 'Domain';e = {Decrypt $_.Domain}},
             @{l = 'Preference';e = {Decrypt $_.Preference}},
-            @{l = 'ServiceAccountClientID';e = {Decrypt $_.ServiceAccountClientID}},
+            @{l = 'ServiceAccountClientID';e = {
+                if ($_.JSONServiceAccountKey) {
+                    ($_.JSONServiceAccountKey | ConvertFrom-Json).client_id
+                }
+                else {
+                    Decrypt $_.ServiceAccountClientID
+                }
+            }},
             @{l = 'Chat';e = {
                 $dict = @{
                     Webhooks = @{}

--- a/PSGSuite/Public/Configuration/Get-PSGSuiteConfig.ps1
+++ b/PSGSuite/Public/Configuration/Get-PSGSuiteConfig.ps1
@@ -65,6 +65,8 @@ function Get-PSGSuiteConfig {
             @{l = 'ConfigName';e = {$choice}},
             @{l = 'P12KeyPath';e = {Decrypt $_.P12KeyPath}},
             'P12Key',
+            @{l = 'P12KeyPassword';e = {Decrypt $_.P12KeyPassword}},
+            'P12KeyObject',
             @{l = 'ClientSecretsPath';e = {Decrypt $_.ClientSecretsPath}},
             @{l = 'ClientSecrets';e = {Decrypt $_.ClientSecrets}},
             @{l = 'AppEmail';e = {Decrypt $_.AppEmail}},

--- a/PSGSuite/Public/Configuration/Get-PSGSuiteConfig.ps1
+++ b/PSGSuite/Public/Configuration/Get-PSGSuiteConfig.ps1
@@ -57,6 +57,9 @@ function Get-PSGSuiteConfig {
                     [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR(
                         $String))
             }
+            elseif ($String -is [ScriptBlock]) {
+                $String.InvokeReturnAsIs()
+            }
             else {
                 $String
             }

--- a/PSGSuite/Public/Configuration/Get-PSGSuiteConfig.ps1
+++ b/PSGSuite/Public/Configuration/Get-PSGSuiteConfig.ps1
@@ -70,16 +70,14 @@ function Get-PSGSuiteConfig {
             'P12Key',
             @{l = 'P12KeyPassword';e = {Decrypt $_.P12KeyPassword}},
             @{l = 'P12KeyObject';e = {Decrypt $_.P12KeyObject}},
-            @{l = 'JSONServiceAccountKeyPath';e = {Decrypt $_.JSONServiceAccountKeyPath}},
-            @{l = 'JSONServiceAccountKey';e = {Decrypt $_.JSONServiceAccountKey}},
             @{l = 'ClientSecretsPath';e = {Decrypt $_.ClientSecretsPath}},
             @{l = 'ClientSecrets';e = {Decrypt $_.ClientSecrets}},
             @{l = 'AppEmail';e = {
-                if ($_.JSONServiceAccountKey) {
-                    ($_.JSONServiceAccountKey | ConvertFrom-Json).client_email
+                if ($_.AppEmail) {
+                    Decrypt $_.ServiceAccountClientID
                 }
-                else {
-                    Decrypt $_.AppEmail
+                elseif ($_.ClientSecrets) {
+                    (Decrypt $_.ClientSecrets | ConvertFrom-Json).client_email
                 }
             }},
             @{l = 'AdminEmail';e = {Decrypt $_.AdminEmail}},
@@ -87,11 +85,11 @@ function Get-PSGSuiteConfig {
             @{l = 'Domain';e = {Decrypt $_.Domain}},
             @{l = 'Preference';e = {Decrypt $_.Preference}},
             @{l = 'ServiceAccountClientID';e = {
-                if ($_.JSONServiceAccountKey) {
-                    ($_.JSONServiceAccountKey | ConvertFrom-Json).client_id
-                }
-                else {
+                if ($_.ServiceAccountClientID) {
                     Decrypt $_.ServiceAccountClientID
+                }
+                elseif ($_.ClientSecrets) {
+                    (Decrypt $_.ClientSecrets | ConvertFrom-Json).client_id
                 }
             }},
             @{l = 'Chat';e = {

--- a/PSGSuite/Public/Configuration/Set-PSGSuiteConfig.ps1
+++ b/PSGSuite/Public/Configuration/Set-PSGSuiteConfig.ps1
@@ -25,10 +25,10 @@ function Set-PSGSuiteConfig {
     The string contents of the Serivce Account JSON file downloaded from the Google Developer's Console.
 
     .PARAMETER ClientSecretsPath
-    The path to the Client Secrets JSON file downloaded from the Google Developer's Console. Using the ClientSecrets JSON will prompt the user to complete OAuth2 authentication in their browser on the first run and store the retrieved Refresh and Access tokens in the user's home directory. The config will auto-update with this value after running any command, if ClientSecretsPath is filled and this value is not already present. If P12KeyPath is also specified, ClientSecretsPath will be ignored.
+    The path to the Client Secrets JSON file downloaded from the Google Developer's Console. Using the ClientSecrets JSON will prompt the user to complete OAuth2 authentication in their browser on the first run and store the retrieved Refresh and Access tokens in the user's home directory. The config will auto-update with this value after running any command, if ClientSecretsPath is filled and this value is not already present. If JSONServiceAccountKeyPath or P12KeyPath is also specified, ClientSecretsPath will be ignored.
 
     .PARAMETER ClientSecrets
-    The string contents of the Client Secrets JSON file downloaded from the Google Developer's Console. Using the ClientSecrets JSON will prompt the user to complete OAuth2 authentication in their browser on the first run and store the retrieved Refresh and Access tokens in the user's home directory. If P12KeyPath is also specified, ClientSecrets will be ignored.
+    The string contents of the Client Secrets JSON file downloaded from the Google Developer's Console. Using the ClientSecrets JSON will prompt the user to complete OAuth2 authentication in their browser on the first run and store the retrieved Refresh and Access tokens in the user's home directory. If JSONServiceAccountKeyPath or P12KeyPath is also specified, ClientSecrets will be ignored.
 
     .PARAMETER AppEmail
     The application email from the Google Developer's Console. This typically looks like the following:

--- a/PSGSuite/Public/Configuration/Set-PSGSuiteConfig.ps1
+++ b/PSGSuite/Public/Configuration/Set-PSGSuiteConfig.ps1
@@ -15,6 +15,9 @@ function Set-PSGSuiteConfig {
     .PARAMETER P12Key
     The P12Key in byte array format. If the actual P12Key is present on the config, the P12KeyPath is not needed. The config will auto-update with this value after running any command, if P12KeyPath is filled and this value is not already present.
 
+    .PARAMETER P12KeyPassword
+    The password for the P12 Key file. If not specified the default of 'notasecret' will be used and this config value will not be set. This is only needed in the case where the P12 file has been manually rexported with a custom password
+
     .PARAMETER ClientSecretsPath
     The path to the Client Secrets JSON file downloaded from the Google Developer's Console. Using the ClientSecrets JSON will prompt the user to complete OAuth2 authentication in their browser on the first run and store the retrieved Refresh and Access tokens in the user's home directory. The config will auto-update with this value after running any command, if ClientSecretsPath is filled and this value is not already present. If P12KeyPath is also specified, ClientSecretsPath will be ignored.
 
@@ -95,6 +98,9 @@ function Set-PSGSuiteConfig {
         [Byte[]]
         $P12Key,
         [parameter(Mandatory = $false,ValueFromPipelineByPropertyName = $true)]
+        [SecureString]
+        $P12KeyPassword,
+        [parameter(Mandatory = $false,ValueFromPipelineByPropertyName = $true)]
         [string]
         $ClientSecretsPath,
         [parameter(Mandatory = $false,ValueFromPipelineByPropertyName = $true)]
@@ -164,7 +170,7 @@ function Set-PSGSuiteConfig {
             }
         }
         Write-Verbose "Setting config name '$ConfigName'"
-        $configParams = @('P12Key','P12KeyPath','ClientSecretsPath','ClientSecrets','AppEmail','AdminEmail','CustomerID','Domain','Preference','ServiceAccountClientID','Webhook','Space')
+        $configParams = @('P12Key','P12KeyPath','P12KeyPassword','ClientSecretsPath','ClientSecrets','AppEmail','AdminEmail','CustomerID','Domain','Preference','ServiceAccountClientID','Webhook','Space')
         if ($SetAsDefaultConfig -or !$configHash["DefaultConfig"]) {
             $configHash["DefaultConfig"] = $ConfigName
         }
@@ -188,6 +194,11 @@ function Set-PSGSuiteConfig {
                     if (-not [System.String]::IsNullOrWhiteSpace($PSBoundParameters[$key].Trim())) {
                         $configHash["$ConfigName"][$key] = (Encrypt $PSBoundParameters[$key])
                         $configHash["$ConfigName"]['P12Key'] = ([System.IO.File]::ReadAllBytes($PSBoundParameters[$key]))
+                    }
+                }
+                P12KeyPassword {
+                    if (-not [System.String]""::IsNullOrWhiteSpace($PSBoundParameters[$key].Trim())) {
+                        $configHash["$ConfigName"][$key] = (Encrypt $PSBoundParameters[$key])
                     }
                 }
                 ClientSecretsPath {

--- a/PSGSuite/Public/Configuration/Set-PSGSuiteConfig.ps1
+++ b/PSGSuite/Public/Configuration/Set-PSGSuiteConfig.ps1
@@ -18,6 +18,12 @@ function Set-PSGSuiteConfig {
     .PARAMETER P12KeyPassword
     The password for the P12 Key file. If not specified the default of 'notasecret' will be used and this config value will not be set. This is only needed in the case where the P12 file has been manually rexported with a custom password
 
+    .PARAMETER JSONServiceAccountKeyPath
+    The path to the Service Account JSON file downloaded from the Google Developer's Console.
+
+    .PARAMETER JSONServiceAccountKey
+    The string contents of the Serivce Account JSON file downloaded from the Google Developer's Console.
+
     .PARAMETER ClientSecretsPath
     The path to the Client Secrets JSON file downloaded from the Google Developer's Console. Using the ClientSecrets JSON will prompt the user to complete OAuth2 authentication in their browser on the first run and store the retrieved Refresh and Access tokens in the user's home directory. The config will auto-update with this value after running any command, if ClientSecretsPath is filled and this value is not already present. If P12KeyPath is also specified, ClientSecretsPath will be ignored.
 
@@ -102,6 +108,12 @@ function Set-PSGSuiteConfig {
         $P12KeyPassword,
         [parameter(Mandatory = $false,ValueFromPipelineByPropertyName = $true)]
         [string]
+        $JSONServiceAccountKeyPath,
+        [parameter(Mandatory = $false,ValueFromPipelineByPropertyName = $true)]
+        [string]
+        $JSONServiceAccountKey,
+        [parameter(Mandatory = $false,ValueFromPipelineByPropertyName = $true)]
+        [string]
         $ClientSecretsPath,
         [parameter(Mandatory = $false,ValueFromPipelineByPropertyName = $true)]
         [string]
@@ -151,6 +163,9 @@ function Set-PSGSuiteConfig {
             elseif ($string -is [System.String] -and $String -notlike '') {
                 ConvertTo-SecureString -String $string -AsPlainText -Force
             }
+            elseif ($string -is [System.Management.Automation.ScriptBlock]) {
+                $string
+            }
         }
     }
     Process {
@@ -170,7 +185,7 @@ function Set-PSGSuiteConfig {
             }
         }
         Write-Verbose "Setting config name '$ConfigName'"
-        $configParams = @('P12Key','P12KeyPath','P12KeyPassword','ClientSecretsPath','ClientSecrets','AppEmail','AdminEmail','CustomerID','Domain','Preference','ServiceAccountClientID','Webhook','Space')
+        $configParams = @('P12Key','P12KeyPath','P12KeyPassword','JSONServiceAccountKeyPath','JSONServiceAccountKey','ClientSecretsPath','ClientSecrets','AppEmail','AdminEmail','CustomerID','Domain','Preference','ServiceAccountClientID','Webhook','Space')
         if ($SetAsDefaultConfig -or !$configHash["DefaultConfig"]) {
             $configHash["DefaultConfig"] = $ConfigName
         }
@@ -199,6 +214,12 @@ function Set-PSGSuiteConfig {
                 P12KeyPassword {
                     if (-not [System.String]""::IsNullOrWhiteSpace($PSBoundParameters[$key].Trim())) {
                         $configHash["$ConfigName"][$key] = (Encrypt $PSBoundParameters[$key])
+                    }
+                }
+                JSONServiceAccountKeyPath {
+                    if (-not [System.String]::IsNullOrWhiteSpace($PSBoundParameters[$key].Trim())) {
+                        $configHash["$ConfigName"][$key] = (Encrypt $PSBoundParameters[$key])
+                        $configHash["$ConfigName"]['JSONServiceAccountKey'] = (Encrypt $(Get-Content $PSBoundParameters[$key] -Raw))
                     }
                 }
                 ClientSecretsPath {

--- a/PSGSuite/Public/Configuration/Set-PSGSuiteConfig.ps1
+++ b/PSGSuite/Public/Configuration/Set-PSGSuiteConfig.ps1
@@ -18,12 +18,6 @@ function Set-PSGSuiteConfig {
     .PARAMETER P12KeyPassword
     The password for the P12 Key file. If not specified the default of 'notasecret' will be used and this config value will not be set. This is only needed in the case where the P12 file has been manually rexported with a custom password
 
-    .PARAMETER JSONServiceAccountKeyPath
-    The path to the Service Account JSON file downloaded from the Google Developer's Console.
-
-    .PARAMETER JSONServiceAccountKey
-    The string contents of the Serivce Account JSON file downloaded from the Google Developer's Console.
-
     .PARAMETER ClientSecretsPath
     The path to the Client Secrets JSON file downloaded from the Google Developer's Console. Using the ClientSecrets JSON will prompt the user to complete OAuth2 authentication in their browser on the first run and store the retrieved Refresh and Access tokens in the user's home directory. The config will auto-update with this value after running any command, if ClientSecretsPath is filled and this value is not already present. If JSONServiceAccountKeyPath or P12KeyPath is also specified, ClientSecretsPath will be ignored.
 
@@ -108,12 +102,6 @@ function Set-PSGSuiteConfig {
         $P12KeyPassword,
         [parameter(Mandatory = $false,ValueFromPipelineByPropertyName = $true)]
         [string]
-        $JSONServiceAccountKeyPath,
-        [parameter(Mandatory = $false,ValueFromPipelineByPropertyName = $true)]
-        [string]
-        $JSONServiceAccountKey,
-        [parameter(Mandatory = $false,ValueFromPipelineByPropertyName = $true)]
-        [string]
         $ClientSecretsPath,
         [parameter(Mandatory = $false,ValueFromPipelineByPropertyName = $true)]
         [string]
@@ -185,7 +173,7 @@ function Set-PSGSuiteConfig {
             }
         }
         Write-Verbose "Setting config name '$ConfigName'"
-        $configParams = @('P12Key','P12KeyPath','P12KeyPassword','JSONServiceAccountKeyPath','JSONServiceAccountKey','ClientSecretsPath','ClientSecrets','AppEmail','AdminEmail','CustomerID','Domain','Preference','ServiceAccountClientID','Webhook','Space')
+        $configParams = @('P12Key','P12KeyPath','P12KeyPassword','ClientSecretsPath','ClientSecrets','AppEmail','AdminEmail','CustomerID','Domain','Preference','ServiceAccountClientID','Webhook','Space')
         if ($SetAsDefaultConfig -or !$configHash["DefaultConfig"]) {
             $configHash["DefaultConfig"] = $ConfigName
         }
@@ -212,15 +200,7 @@ function Set-PSGSuiteConfig {
                     }
                 }
                 P12KeyPassword {
-                    if (-not [System.String]""::IsNullOrWhiteSpace($PSBoundParameters[$key].Trim())) {
-                        $configHash["$ConfigName"][$key] = (Encrypt $PSBoundParameters[$key])
-                    }
-                }
-                JSONServiceAccountKeyPath {
-                    if (-not [System.String]::IsNullOrWhiteSpace($PSBoundParameters[$key].Trim())) {
-                        $configHash["$ConfigName"][$key] = (Encrypt $PSBoundParameters[$key])
-                        $configHash["$ConfigName"]['JSONServiceAccountKey'] = (Encrypt $(Get-Content $PSBoundParameters[$key] -Raw))
-                    }
+                    $configHash["$ConfigName"][$key] = $PSBoundParameters[$key]
                 }
                 ClientSecretsPath {
                     if (-not [System.String]::IsNullOrWhiteSpace($PSBoundParameters[$key].Trim())) {


### PR DESCRIPTION
This isn't fully ready to be merged, but I wanted to open this PR to see how you feel about these changes.

I'm trying to migrate from a Google API module my team has written, [UMN-Google](https://github.com/umn-microsoft-automation/UMN-Google), to this module.  Our primary use case is running from within Azure Automation.  Additionally, We're currently using a service account with a .p12 cert to do all our authentication, though our .p12 isn't a super admin, it's just a "regular" user in our domain.  Additionally, when we first created our .p12 cert we re-exported it with a new more secure password, instead of `notasecret`.

So the first change I've made here is to create a `P12KeyPassword` config item.  It can be specified with `Set-PSGSuiteConfig`.  If it exists, `New-GoogleService` will use it instead of the default password.  I've constructed it in the way I have such that, if someone doesn't use this parameter, they'll never see it in their config.  This also makes it backwards compatible with existing configs, and doesn't require anything like setting the `notasecret` password in every config file.

The rest of the changes are because of our primary use case, Azure Automation. First I'll note that I wrote the rest of this before I saw the `Import` and `Export` Config commands.  So it's entirely possible I could be using those, but at a first glance I don't think they'd fully work in my scenario.

Azure Automation has its own secrets management. It can store/retrieve strings.  It can also store/retreive a few object types, like `PSCredential` and `X509Certificate2`.  Because we do all our secrets management in Azure Automation directly, I don't want to have to do any work to store my configuration on the actual machine, and make the deployment of new HybridRunbookWorkers as simple and automated as possible.

So first, I've modified the `Get-PSGsuiteConfig` function, specifically the internal `Decrypt` function.  Now it will "decrypt" one additional datatype, a `ScriptBlock`.  It does this by actually executing the ScriptBlock, which makes the configuration incredibly versatile.  I haven't modified the corresponding `Set` command for this, because I think it may be advanced enough that someone should have to edit their Configuration by hand if they want to do it.

In Azure Automation if I want to retrieve a string value, I would use the command `Get-AutomationVariable -Name <name>`.  For example if I stored my App Email in a variable called `gcert-email` then `Get-AutomationVariable -Name 'gcert-email'` in a runbook would return the App Email.  Then I can do something like this in my Configuration, making it fully portable:
```powershell
AppEmail = (ScriptBlock "Get-AutomationVariable -Name 'gcert-email'")
```
The ScriptBlock construction here is a feature of the Configuration module, when it deseralizes this, the `AppEmail` property will be an actual ScriptBlock

To Decrypt this I added another case, if the `$String` being decrypted is of type `[ScriptBlock]` it will execute it and return whatever it returns.  In my case it will return an actual string, so the end result is the `AppEmail` config item is being set and defined by my Azure Automation Variable.

Azure Automation can also produce exportable passwordless certificates, in the same format as your certificate construction code currently takes.  So I've added another config that can be retreived with `Get-PSGsuiteConfig`, `P12KeyObject`.  If `P12KeyObject` is defined, `New-GoogleService` will skip trying to write the bytes of the password protected cert, and skip creating the certificate object, and just use the value of `P12KeyObject` directly.

The end result of all this is I can write a config file that looks like this:
```powershell
@{
  aaservice = @{
    ConfigPath = 'C:\ProgramData\powershell\SCRT HQ\PSGSuite\Configuration.psd1'
    AppEmail = (ScriptBlock "Get-AutomationVariable -Name 'gcert-email'")
    AdminEmail = (ScriptBlock "Get-AutomationVariable -Name 'gcert-email'")
    P12KeyObject = (ScriptBlock "Get-AutomationCertificate -Name 'gcert'")
  }
  DefaultConfig = 'aaservice'
}
```

I've been able to test this in my environment, but that's the extent of testing I've done.  I'm opening this to see what you think about this, to determine if I'll put more work into making it merge ready.