### PR TITLE
Allow array input for $User

### DIFF
--- a/PSGSuite/Public/Gmail/Get-GSGmailMessageList.ps1
+++ b/PSGSuite/Public/Gmail/Get-GSGmailMessageList.ps1
@@ -45,7 +45,7 @@ function Get-GSGmailMessageList {
     (
         [parameter(Mandatory = $false,ValueFromPipelineByPropertyName = $true)]
         [Alias("PrimaryEmail","UserKey","Mail")]
-        [String]
+        [String[]]
         $User = $Script:PSGSuite.AdminEmail,
         [parameter(Mandatory = $false,ParameterSetName = "Filter")]
         [Alias('Query')]


### PR DESCRIPTION
Since we already run "foreach" on the $User, thought we can allow this to be an Array String input.
I have also tested it, and it works as expected, I got the multiple user output for my search.