### PR TITLE
new InputObject parameter

### DIFF
--- a/PSGSuite/Public/Drive/Get-GSDriveFileList.ps1
+++ b/PSGSuite/Public/Drive/Get-GSDriveFileList.ps1
@@ -120,12 +120,7 @@ function Get-GSDriveFileList {
         }
     }
     Process {
-        if ($User -ceq 'me') {
-            $User = $Script:PSGSuite.AdminEmail
-        }
-        elseif ($User -notlike "*@*.*") {
-            $User = "$($User)@$($Script:PSGSuite.Domain)"
-        }
+        Resolve-Email ([ref]$User)
         $serviceParams = @{
             Scope       = 'https://www.googleapis.com/auth/drive'
             ServiceType = 'Google.Apis.Drive.v3.DriveService'

--- a/PSGSuite/Public/Drive/Remove-GSDriveFile.ps1
+++ b/PSGSuite/Public/Drive/Remove-GSDriveFile.ps1
@@ -36,8 +36,7 @@ function Remove-GSDriveFile {
         [parameter(ValueFromPipeline = $true, ParameterSetName = "FileObjectSet")]
         [Google.Apis.Drive.v3.Data.File[]]
         $InputObject,        
-        [parameter(ValueFromPipelineByPropertyName = $true, ParameterSetName = "FileIdSet")]
-        [parameter(ValueFromPipelineByPropertyName = $true, ParameterSetName = "FileObjectSet")]
+        [parameter(ValueFromPipelineByPropertyName = $true)]
         [Alias('Owner', 'PrimaryEmail', 'UserKey', 'Mail')]
         [string]
         $User = $Script:PSGSuite.AdminEmail        

--- a/PSGSuite/Public/Drive/Remove-GSDriveFile.ps1
+++ b/PSGSuite/Public/Drive/Remove-GSDriveFile.ps1
@@ -23,7 +23,7 @@ function Remove-GSDriveFile {
     Deletes the file with ID 1rhsAYTOB_vrpvfwImPmWy0TcVa2sgmQa_9u976 from the user user@domain.com's Drive
     
     .EXAMPLE
-    Get-GSDriveFileList -FileId '1rhsAYTOB_vrpvfwImPmWy0TcVa2sgmQa_9u976' -User user@domain.com | Remove-GSDriveFile
+    Get-GSDriveFileList -ParentFolderId '1rhsAYTOB_vrpvfwImPmWy0TcVa2sgmQa_9u976' -User user@domain.com | Remove-GSDriveFile
 
     Get the file with ID 1rhsAYTOB_vrpvfwImPmWy0TcVa2sgmQa_9u976 from the user user@domain.com's Drive and pipeline
     #>

--- a/PSGSuite/Public/Drive/Remove-GSDriveFile.ps1
+++ b/PSGSuite/Public/Drive/Remove-GSDriveFile.ps1
@@ -23,14 +23,14 @@ function Remove-GSDriveFile {
     Deletes the file with ID 1rhsAYTOB_vrpvfwImPmWy0TcVa2sgmQa_9u976 from the user user@domain.com's Drive
     
     .EXAMPLE
-    Get-GSDriveFile -FileId '1rhsAYTOB_vrpvfwImPmWy0TcVa2sgmQa_9u976' -User user@domain.com | Remove-GSDriveFile
+    Get-GSDriveFileList -FileId '1rhsAYTOB_vrpvfwImPmWy0TcVa2sgmQa_9u976' -User user@domain.com | Remove-GSDriveFile
 
     Get the file with ID 1rhsAYTOB_vrpvfwImPmWy0TcVa2sgmQa_9u976 from the user user@domain.com's Drive and pipeline
     #>
     [cmdletbinding(SupportsShouldProcess = $true, ConfirmImpact = "High")]
     Param
     (
-        [parameter(Position = 0, ParameterSetName = "FileIdSet")]
+        [parameter(Mandatory = $true, Position = 0, ParameterSetName = "FileIdSet")]
         [String[]]
         $FileId,
         [parameter(ValueFromPipeline = $true, ParameterSetName = "FileObjectSet")]
@@ -97,7 +97,6 @@ function Remove-GSDriveFile {
         
         foreach ($obj in $InputObject) {
             deleteUserFile -User $User -FileId $obj.Id
-        }
-        
+        }       
     }
 }


### PR DESCRIPTION
This PR includes changes to the Remove-GSDriveFile cmdlet, moving invariants to the Begin clause and introducing parameter sets. The new InputObject parameter provides for deleting either a File[] or pipelined File objects (from Get-GSDriveFileList, for example). The FileId parameter is made optional to preclude prompting. FileId and InputObject are mutually exclusive, but leaving both unset is okay - nothing happens.