### PR TITLE
Added `-DebugBuild` parameter to build.ps1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,12 @@
 
 # PSGSuite - ChangeLog
 
+## 3.#.# - 2025-##-##
+
+- Added `-DebugBuild` switch to `build.ps1` for improved module debugging. The compiled `PSGSuite.psm1` file will:
+  - Link directly to each source code file found in the `PSGSuite` directory.
+  - Export all module functions and variables to the PowerShell session.
+
 ## 3.0.0 - 2024-11-20
 
 ### Breaking Changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,8 +115,12 @@ Install MkDocs and its dependencies using the provided requirements.txt file.
 
 ### Enabling Debug Mode
 
-> [!WARNING]
-> TODO: Add instructions for how to use `build.ps1` to enable debug mode for the module.
+A debug build of the module can be built by providing the `-DebugBuild` switch to `build.ps1`.
+
+Debug builds contain the following changes:
+
+- All source code is dot sourced within the compiled module instead of being copied directly into the `psgsuite.psm1` file.
+- All module functions and variables are exported to the PowerShell session.
 
 ### Google .NET SDK Documentation
 

--- a/build.ps1
+++ b/build.ps1
@@ -10,7 +10,8 @@ param(
 
     [switch]$UpdateModules,
     [switch]$Force,
-    [switch]$Help
+    [switch]$Help,
+    [switch]$DebugBuild
 )
 $env:_BuildStart = Get-Date -Format 'o'
 $ModuleName = 'PSGSuite'
@@ -45,6 +46,7 @@ else {
 
     $env:BuildProjectName = $ModuleName
     $env:BuildScriptPath = $PSScriptRoot
+    $env:BuildDebug = $DebugBuild
 
     if ($Task -contains 'Docs') {
         $env:NoNugetRestore = $true

--- a/psake.ps1
+++ b/psake.ps1
@@ -100,21 +100,42 @@ Task Compile -Depends Clean {
     Write-BuildLog 'Creating psm1...'
     $psm1 = Copy-Item -Path (Join-Path -Path $sut -ChildPath 'PSGSuite.psm1') -Destination (Join-Path -Path $outputModVerDir -ChildPath "$($ENV:BHProjectName).psm1") -PassThru
 
-    foreach ($scope in @('Private', 'Public')) {
-        Write-BuildLog "Copying contents from files in source folder to PSM1: $($scope)"
-        $gciPath = Join-Path $sut $scope
-        if (Test-Path $gciPath) {
-            Get-ChildItem -Path $gciPath -Filter "*.ps1" -Recurse -File | ForEach-Object {
-                Write-BuildLog "Working on: $scope$([System.IO.Path]::DirectorySeparatorChar)$($_.FullName.Replace("$gciPath$([System.IO.Path]::DirectorySeparatorChar)",'') -replace '\.ps1$')"
-                [System.IO.File]::AppendAllText($psm1, ("$([System.IO.File]::ReadAllText($_.FullName))`n"))
-                if ($scope -eq 'Public') {
-                    $functionsToExport += $_.BaseName
-                    [System.IO.File]::AppendAllText($psm1, ("Export-ModuleMember -Function '$($_.BaseName)'`n"))
+    If (-not $ENV:BuildDebug){
+        
+        # Normal build
+        # Source code will be copied into the compiled module
+        foreach ($scope in @('Private', 'Public')) {
+            Write-BuildLog "Copying contents from files in source folder to PSM1: $($scope)"
+            $gciPath = Join-Path $sut $scope
+            if (Test-Path $gciPath) {
+                Get-ChildItem -Path $gciPath -Filter "*.ps1" -Recurse -File | ForEach-Object {
+                    Write-BuildLog "Working on: $scope$([System.IO.Path]::DirectorySeparatorChar)$($_.FullName.Replace("$gciPath$([System.IO.Path]::DirectorySeparatorChar)",'') -replace '\.ps1$')"
+                    [System.IO.File]::AppendAllText($psm1, ("$([System.IO.File]::ReadAllText($_.FullName))`n"))
+                    if ($scope -eq 'Public') {
+                        $functionsToExport += $_.BaseName
+                        [System.IO.File]::AppendAllText($psm1, ("Export-ModuleMember -Function '$($_.BaseName)'`n"))
+                    }
                 }
             }
         }
-    }
+    
+    } else {
+        
+        # Debug Build
+        # The module will link directly to the .ps1 files in the source directory for convenient debugging.
+        foreach ($scope in @('Private', 'Public')) {
+            Write-BuildLog "Linking files in source folder to PSM1: $($scope)"
+            $gciPath = Join-Path $sut $scope
+            if (Test-Path $gciPath) {
+                Get-ChildItem -Path $gciPath -Filter "*.ps1" -Recurse -File | ForEach-Object {
+                    Write-BuildLog "Working on: $scope$([System.IO.Path]::DirectorySeparatorChar)$($_.FullName.Replace("$gciPath$([System.IO.Path]::DirectorySeparatorChar)",'') -replace '\.ps1$')"
+                    [System.IO.File]::AppendAllText($psm1, (". '$($_.FullName)'`n"))
+                }
+            }
+        }
+        [System.IO.File]::AppendAllText($psm1, ("Export-ModuleMember -Function * -Variable *"))
 
+    }
 
     Invoke-CommandWithLog { Remove-Module $env:BHProjectName -ErrorAction SilentlyContinue -Force -Verbose:$false }
 
@@ -259,7 +280,15 @@ catch {
     Copy-Item -Path $env:BHPSModuleManifest -Destination $outputModVerDir
 
     # Update FunctionsToExport on manifest
-    Update-ModuleManifest -Path (Join-Path $outputModVerDir "$($env:BHProjectName).psd1") -FunctionsToExport ($functionsToExport | Sort-Object) -AliasesToExport ($aliasesToExport | Sort-Object)
+    If (-not $ENV:BuildDebug){
+        # Normal build
+        Update-ModuleManifest -Path (Join-Path $outputModVerDir "$($env:BHProjectName).psd1") -FunctionsToExport ($functionsToExport | Sort-Object) -AliasesToExport ($aliasesToExport | Sort-Object)
+    } else {
+        #Debug build
+        write-host $outputModVerDir
+        write-host "$($env:BHProjectName).psd1"
+        Update-ModuleManifest -Path (Join-Path $outputModVerDir "$($env:BHProjectName).psd1") -FunctionsToExport '*' -AliasesToExport '*' -VariablesToExport '*'
+    }
 
     if ((Get-ChildItem $outputModVerDir | Where-Object { $_.Name -eq "$($env:BHProjectName).psd1" }).BaseName -cne $env:BHProjectName) {
         "    Renaming manifest to correct casing"


### PR DESCRIPTION
I could see some mentions in the documentation of debugging capabilities in the `build.ps1` file but I was unable to find anything in the file to support that.

So I have added a `-BuildDebug` switch to `build.ps1` that will cause a debug build to be created. The main differences are:

- All source code files will be dot sourced in the compiled module. This is instead of copying all code into the `psgsuite.psm1` file.
- All module functions and variables are exported to the PowerShell session.