### PR TITLE
Added Get-GSChromePolicySchema and Resolve-GSChromePolicy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,12 @@
 
 # PSGSuite - ChangeLog
 
+## 3.X.X - XXXX-XX-XX
+
+- Added function `Get-GSChromePolicySchema` to allow viewing the Chrome Policies that are available in the Admin Console.
+- Added function `Resolve-GSChromePolicySchema` to allow viewing the Chrome Policies that have been configured in the Admin Console.
+- Added private function `Invoke-GSPaginatedRequest` for handling paginated requests.
+
 ## 3.0.0 - 2024-11-20
 
 ### Breaking Changes

--- a/PSGSuite/Private/Requests/Invoke-GSPaginatedRequest.ps1
+++ b/PSGSuite/Private/Requests/Invoke-GSPaginatedRequest.ps1
@@ -1,0 +1,146 @@
+Function Invoke-GSPaginatedRequest {
+    <#
+    .SYNOPSIS
+    Provides a reusbale framework for executing paginated requests.
+
+    .DESCRIPTION
+    Provides a reusbale framework for executing paginated requests.
+
+    .PARAMETER Request
+    The service request object that is to be executed.
+
+    .PARAMETER Body
+    The body object that is sent with the request.
+    
+    The object passed to this parameter must be the same instance that was used to instatiate the request object.
+
+    .PARAMETER PageSize
+    The maximum page size. If not specified the default value is 200.
+
+    .PARAMETER Limit
+    The maximum amount of results you want returned. Exclude or set to 0 to return all results
+
+    .EXAMPLE
+    $service = New-GoogleService @serviceParams
+    $Request = $service.resource.List("customers/$CustomerID")
+    $Results = Invoke-GSPaginatedRequest -Request $Request
+
+    .EXAMPLE
+    $service = New-GoogleService @serviceParams
+    $Body = [RequestBody]::new()
+    $Request = $service.resource.List($Body, "customers/$CustomerID")
+    $Results = Invoke-GSPaginatedRequest -Request $Request -Body $Body
+
+    #>
+
+    [CmdletBinding()]
+    [OutputType([System.Object[]])]
+    Param(
+        [Parameter(Mandatory = $True, ParameterSetName = "GET")]
+        [Parameter(Mandatory = $True, ParameterSetName = "POST")]
+        [Google.Apis.Requests.ClientServiceRequest]$Request,
+
+        [Parameter(Mandatory = $True, ParameterSetName = "POST")]
+        [System.Object]$Body,
+
+        [Parameter(Mandatory = $False, ParameterSetName = "GET")]
+        [Parameter(Mandatory = $False, ParameterSetName = "POST")]
+        [Int]$PageSize = 200,
+
+        [Parameter(Mandatory = $False, ParameterSetName = "GET")]
+        [Parameter(Mandatory = $False, ParameterSetName = "POST")]
+        [Int]$Limit = 0
+    )
+
+    Process {
+
+        $APIMethod = $Request.GetType().FullName
+        $PayloadNoun = $Request.GetType().DeclaringType.Name -Replace "Resource$"
+
+        Write-Verbose "Preparing paginated $($PSCmdlet.ParameterSetName) request for $APIMethod"
+
+        # Determine the object that holds the requestParameters
+        If ($PSCmdlet.ParameterSetName -eq "GET"){
+            $RequestParameters = $Request
+        } else {
+            # We are relying on $body being the same instance that was used to instantiate $Request.
+            # This allows us to change the properties attached to $body which also changes the body sent with $Request.Execute()
+            $RequestParameters = $Body
+        }
+
+        # Determine the Page Size property
+        ForEach ($Name in @('PageSize', 'MaxResults')){
+            If (($RequestParameters | Get-Member -Name $Name -MemberType Property)){
+               $PageSizeProperty = $Name
+               Break
+            }
+        }
+        If ($null -eq $PageSizeProperty){
+            ThrowTerm "A PageSize property was not found on the request object."
+        }
+        Write-Verbose "Using '$PageSizeProperty' as the PageSize property."
+
+        # Confirm the result limit        
+        if ($Limit -gt 0 -and $PageSize -gt $Limit) {
+            Write-Verbose ("Reducing PageSize from $PageSize to $Limit to meet limit with first page")
+            $PageSize = $Limit
+        }
+
+        # Set the initial page size
+        $RequestParameters.$PageSizeProperty = $PageSize
+        
+        Write-Verbose "Executing paginated $($PSCmdlet.ParameterSetName) request for $APIMethod"
+        
+        [int]$Retrieved = 0
+        $overLimit = $false
+        
+        do {
+
+            $Result = $Request.Execute()
+
+            # Update Page Token
+            $RequestParameters.PageToken = $result.NextPageToken
+            
+            # Determine the property that contains the results payload from the API call, do this on the first page only.
+            # This assumes that there will be a single property on the returned object that contains the results payload data.
+            If ($Retrieved -eq 0){
+
+                $PayloadProperty = $Result | Get-Member -MemberType Property | Select-Object -ExpandProperty Name | Where-Object {$_ -NotMatch "^(ETag|NextPageToken|Kind)$"}
+                # Confirm the property exists
+                If (($PayloadProperty.count -gt 1) -or ([String]::IsNullOrEmpty($PayloadProperty))){
+                    ThrowTerm "Unable to determine the result property for API method '$APIMethod' on the returned object with type '$($Result.getType().FullName)'."
+                }
+                Write-Verbose "Using '$PayloadProperty' as the payload property."
+
+            }
+
+            # Get the results from the payload property
+            $Output = $Result.$PayloadProperty
+            
+            # Count the retrieved results
+            [int]$retrieved = $Retrieved + $Output.Count
+            Write-Verbose "Retrieved $Retrieved $PayloadNoun..."
+            
+            # Check the result limit
+            if (($Limit -gt 0) -and ($Retrieved -ge $Limit)) {
+
+                Write-Verbose "Limit reached: $Limit"
+                $overLimit = $true
+
+            } elseif (($Limit -gt 0) -and (($Retrieved + $PageSize) -gt $Limit)) {
+                
+                $newPageSize = $Limit - $Retrieved
+                Write-Verbose ("Reducing PageSize from $PageSize to $NewPageSize to meet limit with next page" -f $PageSize, $newPageSize)
+                $RequestParameters.$PageSizeProperty = $NewPageSize
+
+            }
+
+            # Return the results to the pipeline
+            $Output
+
+        } until ($overLimit -or !$Result.NextPageToken)
+
+        Write-Verbose "Completed paginated $($PSCmdlet.ParameterSetName) request for $APIMethod"
+
+    }
+}

--- a/PSGSuite/Public/Chrome/Get-GSChromePolicySchema.ps1
+++ b/PSGSuite/Public/Chrome/Get-GSChromePolicySchema.ps1
@@ -1,0 +1,263 @@
+Function Get-GSChromePolicySchema {
+
+    <#
+    .SYNOPSIS
+    Gets the schema for the specified Chrome policies. Returns the schema for all policies if -Name is excluded.
+
+    .DESCRIPTION
+    Gets the schema for the specified Chrome policies. Returns the schema for all policies if -Name is excluded.
+
+    .NOTES
+    It is possible to access the schema for policies that are available in the Google Admin Console only. If a policy is not available in the Google Admin Console, it cannot be queried with this function.
+
+    Each schema represents a single setting from the Google Admin Console, where the schema's `policyDescription` field often matches the name of the setting.
+
+    A schema's name is its unique identifier, with the following format: `{namespace}.{leafName}`
+
+    A schema contains one or more fields where each field represents a single Chrome configuration policy. The field name often matches the `Chromium name` of each setting that is shown in the Google Admin Console.
+
+    For example, the Google Admin Console user setting `Show sign-out button in tray` is represented by a Schema with the following values:
+      - Schema name: `chrome.users.ShowLogoutButton`
+      - Namespace: `chrome.users`
+      - Leaf name: `ShowLogoutButton`
+      - Contains a field with name: `ShowLogoutButtonInTray`
+      - Policy description: `Show sign-out button in tray.`
+
+
+    .PARAMETER Name
+    The schema or list of schemas for which details should be retrieved. If excluded, all schemas are returned.
+
+    .PARAMETER Namespace
+    The namespace or list of namespaces for which schemas should be retrieved.
+
+    Complete namespace documentation is found here: https://developers.google.com/chrome/policy/guides/policy-schemas
+    
+    .PARAMETER Field
+    Returns the schemas with field names that match the value or list of values provided.
+
+    Field names often match the 'Chromium name' values that are shown in the Google Admin Console.
+
+    .PARAMETER Description
+    Returns the schemas with policy descriptions that contain the value or list of values provided.
+
+    Policy descriptions often match the setting name that is shown in the Google Admin Console.
+
+    .PARAMETER Filter
+    The schema filter used to find a particular schema based on fields like its resource name, description and additionalTargetKeyNames. Complete filter syntax can be found here: https://developers.google.com/chrome/policy/guides/list-policy-schemas
+
+    .PARAMETER Raw
+    If $true, returns the raw response, otherwise, returns a flattened response for readability.
+
+    .PARAMETER PageSize
+    The maximum number of results to return with each request to the API, defaults to 200 and has a maximum of 1000.
+
+    .PARAMETER Limit
+    The maximum amount of results you want returned. Exclude or set to 0 to return all results.
+
+    .EXAMPLE
+    PS > Get-GSChromePolicySchema
+
+    Returns the schema for all policies.
+
+    .EXAMPLE
+    PS > Get-GSChromePolicySchema -Namespace chrome.users
+
+    Returns the schema for all policies from the `chrome.users` namespace.
+
+    .EXAMPLE
+    PS > Get-GSChromePolicySchema -Name chrome.users.ShowLogoutButton
+
+    Returns the `chrome.users.ShowLogoutButton` schema.
+
+    .EXAMPLE
+    PS > Get-GSChromePolicySchema -Field ShowLogoutButtonInTray
+
+    Returns the `chrome.users.ShowLogoutButton` and `chrome.devices.managedguest.ShowLogoutButton` schemas which both contain a field with the name `ShowLogoutButtonInTray`.
+
+    .EXAMPLE
+    PS > Get-GSChromePolicySchema -Description 'Show sign-out button'
+
+    Returns the `chrome.users.ShowLogoutButton` and `chrome.devices.managedguest.ShowLogoutButton` schemas which both contain the `ShowLogoutButtonInTray`.
+
+
+    .LINK
+    https://psgsuite.io/Function%20Help/Chrome/Get-GSChromePolicySchema/
+
+    .LINK
+    https://developers.google.com/chrome/policy/guides/policy-schemas
+
+    .LINK
+    https://developers.google.com/chrome/policy/reference/rest/v1/customers.policySchemas
+
+    .LINK
+    https://chromeenterprise.google/policies/
+
+    #>
+
+    [CmdletBinding(DefaultParameterSetName = 'List.All')]
+    [OutputType('Google.Apis.ChromePolicy.v1.Data.GoogleChromePolicyVersionsV1PolicySchema')]
+    Param(
+
+        [Parameter(Mandatory = $True, ParameterSetName = 'Get')]
+        [Alias('Schema')]
+        [String[]]$Name,
+
+        [Parameter(Mandatory = $True, ParameterSetName = 'List.Namespace')]
+        [ArgumentCompletions(
+            'chrome.devices',
+            'chrome.devices.kiosk',
+            'chrome.devices.kiosk.apps',
+            'chrome.devices.kiosk.appsconfig',
+            'chrome.devices.managedguest',
+            'chrome.devices.managedguest.apps',
+            'chrome.networks.cellular',
+            'chrome.networks.certificates',
+            'chrome.networks.ethernet',
+            'chrome.networks.globalsettings',
+            'chrome.networks.vpn',
+            'chrome.networks.wifi',
+            'chrome.printers',
+            'chrome.printservers',
+            'chrome.users',
+            'chrome.users.apps',
+            'chrome.users.appsconfig'
+        )]
+        [String[]]$Namespace,
+        
+        [Parameter(Mandatory = $True, ParameterSetName = 'List.Field')]
+        [Alias('ChromiumName', 'OnDevicePolicyName', 'Policy')]
+        [String[]]$Field,
+
+        [Parameter(Mandatory = $True, ParameterSetName = 'List.Description')]
+        [Alias('Setting')]
+        [String[]]$Description,
+
+        [Parameter(Mandatory = $True, ParameterSetName = 'List.Filter')]
+        [String]$Filter,
+
+        [Parameter(Mandatory = $False)]
+        [Switch]$Raw,
+
+        [Parameter(Mandatory = $False, ParameterSetName = 'List.Field')]
+        [Parameter(Mandatory = $False, ParameterSetName = 'List.Namespace')]
+        [Parameter(Mandatory = $False, ParameterSetName = 'List.Filter')]
+        [Parameter(Mandatory = $False, ParameterSetName = 'List.Description')]
+        [ValidateRange(1,1000)]
+        [Int]$PageSize = 200,
+
+        [Parameter(Mandatory = $False, ParameterSetName = 'List.Field')]
+        [Parameter(Mandatory = $False, ParameterSetName = 'List.Namespace')]
+        [Parameter(Mandatory = $False, ParameterSetName = 'List.Filter')]
+        [Parameter(Mandatory = $False, ParameterSetName = 'List.Description')]
+        [Int]$Limit = 0
+    )
+
+    Process {
+
+        $customerId = Resolve-GSCustomer
+
+        $serviceParams = @{
+            Scope       = 'https://www.googleapis.com/auth/chrome.management.policy.readonly'
+            ServiceType = 'Google.Apis.ChromePolicy.v1.ChromePolicyService'
+        }
+        $service = New-GoogleService @serviceParams
+
+        Switch -Wildcard ($PSCmdlet.ParameterSetName) {
+            
+            'Get' {
+                
+                ForEach ($Entry in $Name){
+
+                    Write-Verbose "Getting Chrome policy schema '$Entry'"
+                    Try {
+
+                        $Request = $service.Customers.PolicySchemas.Get("customers/$CustomerID/policySchemas/$Entry")
+                        $Request.Execute() | ForEach-Object {
+                            If ($Raw){
+                                $_
+                            } else {
+                                Format-GSChromePolicySchema -Schema $_
+                            }
+                        }
+
+                    } Catch {
+
+                        if ($ErrorActionPreference -eq 'Stop') {
+                            $PSCmdlet.ThrowTerminatingError($_)
+                        } else {
+                            Write-Error $_
+                        }
+
+                    }
+
+                }
+
+            }
+
+            'List.*' {
+
+                $VerbString = "Getting all Chrome policy schemas"
+                
+                $Request = $service.Customers.PolicySchemas.List("customers/$CustomerID")
+
+                Switch ($PSCmdlet.ParameterSetName){
+                    
+                    'List.Field' {
+                        $FilterParts = @()
+                        ForEach ($Entry in $Field){
+                            $FilterParts += "field_descriptions.field=$Entry"
+                        }
+                        $Filter = "$($FilterParts -join " OR ")"
+                    }
+
+                    'List.Namespace' {
+                        $FilterParts = @()
+                        ForEach ($Entry in $Namespace){
+                            $FilterParts += "namespace=$Entry"
+                        }
+                        $Filter = "$($FilterParts -join " OR ")"
+                    }
+
+                    'List.Description' {
+                        $FilterParts = @()
+                        ForEach ($Entry in $description){
+                            $FilterParts += "description=`"$Entry`""
+                        }
+                        $Filter = "$($FilterParts -join " OR ")"
+                    }
+
+                }
+                
+                If ($Filter){
+                    $VerbString += " matching filter '$filter'"
+                    $Request.Filter = $filter
+                }
+
+                Write-Verbose $VerbString
+                Try {
+                    
+                    Invoke-GSPaginatedRequest -Request $Request -PageSize $PageSize -Limit $Limit  | ForEach-Object {
+                        If ($Raw){
+                            $_
+                        } else {
+                            Format-GSChromePolicySchema -Schema $_
+                        }
+                    }
+
+                } Catch {
+
+                    if ($ErrorActionPreference -eq 'Stop') {
+                        $PSCmdlet.ThrowTerminatingError($_)
+                    } else {
+                        Write-Error $_
+                    }
+
+                }
+
+            }
+
+        }
+
+    }
+
+}

--- a/PSGSuite/Public/Chrome/Resolve-GSChromePolicy.ps1
+++ b/PSGSuite/Public/Chrome/Resolve-GSChromePolicy.ps1
@@ -1,0 +1,378 @@
+Function Resolve-GSChromePolicy {
+
+    <#
+    .SYNOPSIS
+    Gets the resolved policy values for a list of policies that match a search query.
+
+    .DESCRIPTION
+    Gets the resolved policy values for a list of policies that match a search query.
+
+    .PARAMETER OrgUnitID
+    The ID or list of IDs of organizational units for which applied policies are to be resolved.
+
+    .PARAMETER Namespace
+    The namespace or list of namespaces from which policy values are to be resolved.
+
+    .PARAMETER Schema
+    The schema or list of schemas from which policy values are to be resolved.
+
+    .PARAMETER AppID
+    The ID or list of IDs of applications for which policy values are to be resolved.
+
+    An appID is formed by combining the app type and app identifier. For example:
+    - `chrome:mkaakpdehdafacodkgkpghoibnmamcme` represents the "Google Drawings" Chrome App
+    - `android:com.google.android.calendar` represents the "Google Calendar" Android app
+    - `web:https://canvas.apps.chrome` represents the "Canvas" Web app
+
+    See notes for further information about target keys.
+
+    .PARAMETER NetworkID
+    The ID or list of IDs of networks for which policy values are to be resolved.
+
+    NetworkID values can be found in the Google Admin Console, or by omitting this parameter to return all configured instances.
+
+    See notes for further information about target keys.
+
+    .PARAMETER PrinterID
+    The ID or list of IDs of printers for which policy values are to be resolved.
+
+    PrinterID values can be found in the Google Admin Console, or by omitting this parameter to return all configured instances.
+
+    See notes for further information about target keys.
+
+    .PARAMETER PrintServerID
+    The ID or list of IDs of print servers for which policy values are to be resolved.
+
+    PrintServerID values can be found in the Google Admin Console, or by omitting this parameter to return all configured instances.
+
+    See notes for further information about target keys.
+
+    .PARAMETER TargetResource
+    The target resource on which the resolved policy is applied. The following resources are supported:
+
+    - Organizational Unit = 'orgunits/$orgunitId'
+    - Group - 'groups/$groupId'
+
+    .PARAMETER SchemaFilter
+    The schema filter, or list of schema filters from which policy values are to be resolved.
+
+    Specify a schema name to view a particular schema, for example: chrome.users.ShowLogoutButton
+
+    Wildcards are supported, but only in the leaf portion of the schema name. Wildcards cannot be used in namespace directly.
+
+    .PARAMETER TargetKey
+    Specifies the target keys used to select specific instances of a schema or namespace. Target Keys are supported only where a schema contains a `additionalTargetKeyNames` section.
+
+    Input is provided as one or more hashtables where key = Key_type and value = target_value.
+
+    For Example: @{'app_id' = 'chrome:mkaakpdehdafacodkgkpghoibnmamcme'}
+    
+    If no target key is provided, all schemas matching the SchemaFilter will be returned.
+
+    See notes for further information about target keys.
+
+    .PARAMETER Raw
+    If $true, returns the raw response, otherwise, returns a flattened response for readability.
+
+    .PARAMETER PageSize
+    The maximum number of results to return with each request to the API, defaults to 200 and has a maximum of 1000.
+
+    .PARAMETER Limit
+    The maximum amount of results you want returned. Exclude or set to 0 to return all results.
+
+    .NOTES
+    A schema's name is its unique identifier, with the following format: `{namespace}.{leafName}`
+
+    For example, given the full schema name of `chrome.users.ShowLogoutButton`. The namespace is `chrome.users` and the leaf name is `ShowLogoutButton`.
+
+    Each schema contains one or more fields where each field represents a single Chrome configuration policy. The field name matches the configuration policy name shown in the Google Admin Console.
+
+    In the above example, the `chrome.users.ShowLogoutButton` schema contains a single field for the configuration policy 'ShowLogoutButtonInTray'.
+
+    Target keys are used to identify specific instances of a configuration schema for items:
+    
+    - Apps
+    - Networks
+    - Printers
+    - Print Servers
+
+    Target Keys are supported only where a schema contains an `additionalTargetKeyNames` section. The following namespaces support target keys and accept keys of the specified type:
+
+    - chrome.devices.kiosk.apps - app_id
+    - chrome.devices.managedguest.apps - app_id
+    - chrome.networks.cellular - network_id
+    - chrome.networks.certificates - network_id
+    - chrome.networks.ethernet - network_id
+    - chrome.networks.vpn - network_id
+    - chrome.networks.wifi - network_id
+    - chrome.printers - printer_id
+    - chrome.printservers - print_server_id
+    - chrome.users.apps - app_id
+
+    .EXAMPLE
+
+    #>
+
+    [CmdletBinding()]
+    Param(
+
+        [Parameter(Mandatory = $True, ParameterSetName = "Resolve.Namespace.OrgUnit")]
+        [Parameter(Mandatory = $True, ParameterSetName = "Resolve.Schema.OrgUnit")]
+        [Parameter(Mandatory = $True, ParameterSetName = "Resolve.App.Namespace.OrgUnit")]
+        [Parameter(Mandatory = $True, ParameterSetName = "Resolve.App.Schema.OrgUnit")]
+        [Parameter(Mandatory = $True, ParameterSetName = "Resolve.Network.Namespace.OrgUnit")]
+        [Parameter(Mandatory = $True, ParameterSetName = "Resolve.Network.Schema.OrgUnit")]
+        [Parameter(Mandatory = $True, ParameterSetName = "Resolve.Printer.Namespace.OrgUnit")]
+        [Parameter(Mandatory = $True, ParameterSetName = "Resolve.Printer.Schema.OrgUnit")]
+        [Parameter(Mandatory = $True, ParameterSetName = "Resolve.PrintServer.Namespace.OrgUnit")]
+        [Parameter(Mandatory = $True, ParameterSetName = "Resolve.PrintServer.Schema.OrgUnit")]
+        [String]$OrgUnitID,
+
+
+        [Parameter(Mandatory = $True, ParameterSetName = "Resolve.Namespace.OrgUnit")]
+        [Parameter(Mandatory = $True, ParameterSetName = "Resolve.App.Namespace.OrgUnit")]
+        [Parameter(Mandatory = $True, ParameterSetName = "Resolve.Network.Namespace.OrgUnit")]
+        [Parameter(Mandatory = $True, ParameterSetName = "Resolve.Printer.Namespace.OrgUnit")]
+        [Parameter(Mandatory = $True, ParameterSetName = "Resolve.PrintServer.Namespace.OrgUnit")]
+        [ArgumentCompletions(
+            'chrome.devices',
+            'chrome.devices.kiosk',
+            'chrome.devices.kiosk.apps',
+            'chrome.devices.kiosk.appsconfig',
+            'chrome.devices.managedguest',
+            'chrome.devices.managedguest.apps',
+            'chrome.networks.cellular',
+            'chrome.networks.certificates',
+            'chrome.networks.ethernet',
+            'chrome.networks.globalsettings',
+            'chrome.networks.vpn',
+            'chrome.networks.wifi',
+            'chrome.printers',
+            'chrome.printservers',
+            'chrome.users',
+            'chrome.users.apps',
+            'chrome.users.appsconfig'
+        )]
+        [String[]]$Namespace,
+
+        [Parameter(Mandatory = $True, ParameterSetName = "Resolve.Schema.OrgUnit")]
+        [Parameter(Mandatory = $True, ParameterSetName = "Resolve.App.Schema.OrgUnit")]
+        [Parameter(Mandatory = $True, ParameterSetName = "Resolve.Network.Schema.OrgUnit")]
+        [Parameter(Mandatory = $True, ParameterSetName = "Resolve.Printer.Schema.OrgUnit")]
+        [Parameter(Mandatory = $True, ParameterSetName = "Resolve.PrintServer.Schema.OrgUnit")]
+        [String[]]$Schema,
+
+
+        [Parameter(Mandatory = $True, ParameterSetName = "Resolve.App.Namespace.OrgUnit")]
+        [Parameter(Mandatory = $True, ParameterSetName = "Resolve.App.Schema.OrgUnit")]
+        [String[]]$AppID,
+
+        [Parameter(Mandatory = $True, ParameterSetName = "Resolve.Network.Namespace.OrgUnit")]
+        [Parameter(Mandatory = $True, ParameterSetName = "Resolve.Network.Schema.OrgUnit")]
+        [String[]]$NetworkID,
+
+        [Parameter(Mandatory = $True, ParameterSetName = "Resolve.Printer.Namespace.OrgUnit")]
+        [Parameter(Mandatory = $True, ParameterSetName = "Resolve.Printer.Schema.OrgUnit")]
+        [String[]]$PrinterID,
+
+        [Parameter(Mandatory = $True, ParameterSetName = "Resolve.PrintServer.Namespace.OrgUnit")]
+        [Parameter(Mandatory = $True, ParameterSetName = "Resolve.PrintServer.Schema.OrgUnit")]
+        [String[]]$PrintServerID,
+
+
+        [Parameter(Mandatory = $True, ParameterSetName = "Resolve.Advanced")]
+        [String[]]$SchemaFilter,
+
+        [Parameter(Mandatory = $True, ParameterSetName = "Resolve.Advanced")]
+        [String[]]$TargetResource,
+
+        [Parameter(Mandatory = $False, ParameterSetName = "Resolve.Advanced")]
+        [Hashtable[]]$TargetKey,
+
+        [Parameter(Mandatory = $False)]
+        [Switch]$Raw,
+
+        [Parameter(Mandatory = $False)]
+        [ValidateRange(1,1000)]
+        [Int]$PageSize = 200,
+
+        [Parameter(Mandatory = $False)]
+        [Int]$Limit = 0
+
+    )
+
+    Process {
+
+        Write-Verbose "Preparing to resolve Chrome policy values"
+
+        # Prepare target resources
+        $TargetResources = @()
+        Switch -Regex ($PSCmdlet.ParameterSetName){
+            '\.OrgUnit$' {
+                ForEach ($Entry in $OrgUnitID){
+                    $TargetResources += "orgunits/$Entry"
+                }
+            }
+            '\.Group$' {
+                ForEach ($Entry in $GroupID){
+                    $TargetResources += "groups/$Entry"
+                }
+            }
+            '^Resolve\.Advanced$' {
+                ForEach ($Entry in $TargetResource){
+                    $TargetResources += "groups/$Entry"
+                }
+            }
+            
+        }
+
+        # Prepare schema filters
+        $SchemaFilters = @()
+        Switch -Regex ($PSCmdlet.ParameterSetName){
+            '\.Schema\.' {
+                ForEach ($Entry in $Schema){
+                    $SchemaFilters += $Entry
+                }
+            }
+            '\.Namespace\.' {
+                ForEach ($Entry in $Namespace){
+                    $SchemaFilters += "$Entry.*"
+                }
+            }
+            '^Resolve\.Advanced$' {
+                ForEach ($Entry in $SchemaFilter){
+                    $SchemaFilters += $Entry
+                }
+            }
+        }
+        
+        # Prepare Target Keys and validate the selected SchemaFilters
+        $TargetKeys = @()
+        $IncompatibleSchemaFilters = @()
+        Switch -Wildcard ($PSCmdlet.ParameterSetName){
+
+            '*App*' {
+                ForEach ($Entry in $AppID){
+                    $TargetKeys += @{'app_id' = $Entry}
+                }
+                $IncompatibleSchemaFilters += $SchemaFilters | Where-Object {$_ -notmatch '^(chrome\.users\.|chrome\.devices\.(kiosk|managedguest)\.)apps\.'}
+            }
+            '*Network*' {
+                ForEach ($Entry in $NetworkID){
+                    $TargetKeys += @{'network_id' = $Entry}
+                }
+                $IncompatibleSchemaFilters += $SchemaFilters | Where-Object {$_ -notmatch '^chrome\.networks\.'}
+            }
+            '*Printer*' {
+                ForEach ($Entry in $PrinterID){
+                    $TargetKeys += @{'printer_id' = $Entry}
+                }
+                $IncompatibleSchemaFilters += $SchemaFilters | Where-Object {$_ -notmatch '^chrome\.printers\.'}
+            }
+            '*PrintServer*' {
+                ForEach ($Entry in $PrintServerID){
+                    $TargetKeys += @{'print_server_id' = $Entry}
+                }
+                $IncompatibleSchemaFilters += $SchemaFilters | Where-Object {$_ -notmatch '^chrome\.printservers\.'}
+            }
+            '*Custom*' {
+                # No validation on custom target key values
+                If ($TargetKey.count){
+                    ForEach ($Entry in $TargetKey){
+                        $TargetKeys += @{'print_server_id' = $Entry}
+                    }
+                } else {
+                    # $null is used as a placeholder to allow the RequestTargetKey loop to iterate
+                    $TargetKeys += $null
+                }
+            }
+            Default {
+                # $null is used as a placeholder to allow the RequestTargetKey loop to iterate
+                $TargetKeys += $null
+            }
+            
+        }
+
+        # If incompatibleSchemas were found, throw an error.
+        If ($IncompatibleSchemaFilters.count){
+            $SchemaString = $SchemaFilters -join "', '"
+            $ResourceString = $TargetResources -join "', '"
+            $TargetKeyType = $($TargetKeys[0].keys)
+            $TargetKeyString = $TargetKeys -join "' }, @{'$TargetKeyType' = '"
+            $SubstituteCommand = "Resolve-GSChromePolicy -TargetResource '$ResourceString' -SchemaFilter '$SchemaString' -TargetKey @{'$TargetKeyType' = '$TargetKeyString'}"
+            $PSCmdlet.ThrowTerminatingError("The selected schemas do not support target keys based on app_id. The incompatible schemas are:`n$($IncompatibleSchemas -join "`n")`n`n To proceed with the request, use the following command:`n$SubstituteCommand")
+        }
+
+        # API Service
+        $serviceParams = @{
+            Scope       = 'https://www.googleapis.com/auth/chrome.management.policy.readonly'
+            ServiceType = 'Google.Apis.ChromePolicy.v1.ChromePolicyService'
+        }
+        $service = New-GoogleService @serviceParams
+
+        # Customer ID
+        $CustomerId = Resolve-GSCustomer
+
+        Write-Verbose "$($TargetResources.count) target resources, $($SchemaFilters.count) schema filters and $($TargetKeys.count) target keys were provided. $($TargetResources.Count * $SchemaFilters.Count * $TargetKeys.count) unique requests are required."
+        
+        ForEach ($RequestTargetResource in $TargetResources){
+
+            ForEach ($RequestSchemaFilter in $SchemaFilters){
+
+                ForEach ($RequestTargetKey in $TargetKeys){
+
+                    If ($RequestTargetKey){
+                        Write-Verbose "Resolving Chrome policy values for resource '$RequestTargetResource' from schema '$RequestSchemaFilter' with target key '$RequestTargetKey'"
+                    } else {
+                        Write-Verbose "Resolving Chrome policy values for resource '$RequestTargetResource' from schema '$RequestSchemaFilter'"
+                    }
+
+                    Try {
+
+                        $Body = [Google.Apis.ChromePolicy.v1.Data.GoogleChromePolicyVersionsV1ResolveRequest]::New()
+                        $Body.PolicySchemaFilter = $RequestSchemaFilter
+                        $PolicyTargetKey = [Google.Apis.ChromePolicy.v1.Data.GoogleChromePolicyVersionsV1PolicyTargetKey]::New()
+                        $PolicyTargetKey.TargetResource = $RequestTargetResource
+                        $PolicyTargetKey.AdditionalTargetKeys = $RequestTargetKey
+                        $Body.PolicyTargetKey = $PolicyTargetKey
+                        $Request = $Service.Customers.Policies.Resolve($Body, "customers/$CustomerID")
+
+                        If ($Raw){
+                            Invoke-GSPaginatedRequest -Request $Request -Body $Body -PageSize $PageSize -Limit $Limit
+                        } else {
+
+                            # Format the response as a flattened object for readability
+                            Invoke-GSPaginatedRequest -Request $Request -Body $Body -PageSize $PageSize -Limit $Limit | ForEach-Object {
+                                
+                                
+
+                                [PSCustomObject]@{
+                                    TargetResource = $_.TargetKey.TargetResource
+                                    SourceResource = $_.SourceKey.TargetResource
+                                    State = ''
+                                    TargetKey = $_.TargetKey.AdditionalTargetKeys
+                                    Schema = $_.value.policySchema
+                                    Value = $_.value.value
+                                }
+                            }
+                        }
+
+                    } Catch {
+
+                        if ($ErrorActionPreference -eq 'Stop') {
+                            $PSCmdlet.ThrowTerminatingError($_)
+                        } else {
+                            Write-Error $_
+                        }
+
+                    }
+
+                }
+
+            }
+
+        }
+
+    }
+
+}

--- a/ci/NuGetDependencies.json
+++ b/ci/NuGetDependencies.json
@@ -42,6 +42,12 @@
     "LatestVersion": "1.41.1.1713"
   },
   {
+    "Name": "Google.Apis.ChromePolicy.v1.dll",
+    "BaseName": "Google.Apis.ChromePolicy.v1",
+    "Target": "Latest",
+    "LatestVersion": "1.69.0.3776"
+  },
+  {
     "Name": "Google.Apis.Classroom.v1.dll",
     "BaseName": "Google.Apis.Classroom.v1",
     "Target": "Latest",


### PR DESCRIPTION
This adds initial support for the Chrome Policy API for managing the configuration of Chrome Policies via the Google Admin Console.

Added functions are:

- `Get-GSChromePolicySchema` - Allows viewing the Chrome configuration policies that are available in the Admin Console.
- `Resolve-GSChromePolicy` - Allows viewing the Chrome configuration policies that have been configured in the Admin Console.
- `Invoke`GSPaginatedRequest` - Private function that provides reusable functionality for handling paginated requests.

@jgeron-suhsd - I realised I was going a bit crazy trying to simplify the output and make it more user friendly, when in reality we should be keeping the raw API output as much as we can. With that in mind, I scrapped a lot of what I had and kept it fairly simple.